### PR TITLE
Don't try to deploy from forks

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -56,9 +56,11 @@ jobs:
       - run: |
           python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: |
+          github.repository == 'JohnPaton/airbase' &&
+          github.event_name == 'push' &&
+          startsWith(github.ref, 'refs/tags')
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
           skip_existing: true
-


### PR DESCRIPTION
The attempted deploy would fail anyway because secrets aren't available to forks, but this will stop it from trying to avoid unnecessary failures. 