### PR TITLE
Switch to setuptools_scm for versioning

### DIFF
--- a/airbase/__init__.py
+++ b/airbase/__init__.py
@@ -1,4 +1,11 @@
 from . import resources, util
+from .__version__ import __version__
 from .airbase import AirbaseClient, AirbaseRequest
 
-__all__ = ["AirbaseClient", "AirbaseRequest", "resources", "util"]
+__all__ = [
+    "AirbaseClient",
+    "AirbaseRequest",
+    "resources",
+    "util",
+    "__version__",
+]

--- a/airbase/__version__.py
+++ b/airbase/__version__.py
@@ -1,0 +1,12 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+try:
+    __version__ = metadata.version("airbase")
+except metadata.PackageNotFoundError:
+    # package isn't installed
+    __version__ = None

--- a/airbase/__version__.py
+++ b/airbase/__version__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info >= (3, 8):
@@ -5,6 +7,7 @@ if sys.version_info >= (3, 8):
 else:
     import importlib_metadata as metadata
 
+__version__: str | None
 try:
     __version__ = metadata.version("airbase")
 except metadata.PackageNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = airbase
-version = 0.3.0
 author = John Paton
 description = An easy downloader for the AirBase air quality data.
 long_description = file: README.md

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import pytest
+
+import airbase
+
+
+@pytest.mark.skipif(airbase.__version__ is None, reason="package not installed")
+def test_version_well_defined():
+    assert 3 <= len(airbase.__version__.split(".")) <= 5


### PR DESCRIPTION
Switches to [`setuptools_scm`](https://pypi.org/project/setuptools-scm/) for versioning. Package version will be determined by git tag, or distance from latest tag in case of installing from untagged source commit. 

Closes #18 