### PR TITLE
add country/pollutant CLI options to airbase all

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Usage: airbase download [OPTIONS]
 
   The -c/--country and -p/--pollutant allow to specify which data to download, e.g.
   - download only Norwegian, Danish and Finish sites
-    airbase all -c NO -c DK -c FI
+    airbase download -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
-    airbase all -p SO2 -p PM10 -p PM2.5
+    airbase download -p SO2 -p PM10 -p PM2.5
 
 Options:
   -c, --country [AD|AL|AT|...]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,33 @@ Downloading CSVs to data...
 Writing metadata to data/metadata.tsv...
 ```
 
+## 🚆 Command line interface
+
+``` bash
+$ airbase download --help
+```
+
+``` man
+Usage: airbase download [OPTIONS]
+
+  Download all pollutants for all countries
+
+  The -c/--country and -p/--pollutant allow to specify which data to download, e.g.
+  - download only Norwegian, Danish and Finish sites
+    airbase all -c NO -c DK -c FI
+  - download only SO2, PM10 and PM2.5 observations
+    airbase all -p SO2 -p PM10 -p PM2.5
+
+Options:
+  -c, --country [AD|AL|AT|...]
+  -p, --pollutant [k|CO|NO|...]
+  --path PATH                     [default: data]
+  --year INTEGER                  [default: 2022]
+  -O, --overwrite                 Re-download existing files.
+  -q, --quiet                     No progress-bar.
+  --help                          Show this message and exit.
+```
+
 ## 🛣 Roadmap
 
 * ~~Parallel CSV downloads~~ Contributed by @avaldebe

--- a/README.md
+++ b/README.md
@@ -92,13 +92,9 @@ Writing metadata to data/metadata.tsv...
 
 ## 🚆 Command line interface
 
-``` bash
+``` console
 $ airbase download --help
-```
-
-``` man
 Usage: airbase download [OPTIONS]
-
   Download all pollutants for all countries
 
   The -c/--country and -p/--pollutant allow to specify which data to download, e.g.

--- a/airbase/__version__.py
+++ b/airbase/__version__.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8):  # pragma: no cover
     from importlib import metadata
-else:
+else:  # pragma: no cover
     import importlib_metadata as metadata
 
 __version__: str | None

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -5,9 +5,9 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import TypedDict
-else:
+else:  # pragma: no cover
     from typing_extensions import TypedDict
 
 from .fetch import (
@@ -59,7 +59,7 @@ class AirbaseClient:
             ]
 
     @property
-    def all_countries(self) -> list[str]:
+    def all_countries(self) -> list[str]:  # pragma: no cover
         warnings.warn(
             f"{type(self).__qualname__}.all_countries has been deprecated and will be removed on v1. "
             f"Use {type(self).__qualname__}.countries instead.",
@@ -69,7 +69,7 @@ class AirbaseClient:
         return self.countries
 
     @property
-    def all_pollutants(self) -> dict[str, str]:
+    def all_pollutants(self) -> dict[str, str]:  # pragma: no cover
         warnings.warn(
             f"{type(self).__qualname__}.all_pollutants has been deprecated and will be removed on v1. "
             f"Use {type(self).__qualname__}._pollutants_ids instead.",

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -87,7 +87,7 @@ def download(
     request.download_to_directory(path, skip_existing=not overwrite)
 
 
-def deprecation_message(old: str, new: str):
+def deprecation_message(old: str, new: str):  # pragma: no cover
     old = typer.style(f"{__package__} {old}", fg=typer.colors.RED, bold=True)
     new = typer.style(f"{__package__} {new}", fg=typer.colors.GREEN, bold=True)
     typer.echo(
@@ -107,7 +107,7 @@ def download_all(
         False, "--overwrite", "-O", help="Re-download existing files."
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
-):
+):  # pragma: no cover
     """Download all pollutants for all countries (deprecated)"""
     deprecation_message("all", "download")
     download(countries, pollutants, path, year, overwrite, quiet)
@@ -125,7 +125,7 @@ def download_country(
         False, "--overwrite", "-O", help="Re-download existing files."
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
-):
+):  # pragma: no cover
     """Download specific pollutants for one country (deprecated)"""
     deprecation_message("country", "download")
     download([country], pollutants, path, year, overwrite, quiet)
@@ -143,7 +143,7 @@ def download_pollutant(
         False, "--overwrite", "-O", help="Re-download existing files."
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
-):
+):  # pragma: no cover
     """Download specific countries for one pollutant (deprecated)"""
     deprecation_message("pollutant", "download")
     download(countries, [pollutant], path, year, overwrite, quiet)

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -21,7 +21,7 @@ class Country(str, Enum):
     _ignore_ = "country Country"  # type:ignore[misc]
 
     Country = vars()
-    for country in client.all_countries:
+    for country in client.countries:
         Country[country] = country
 
 
@@ -29,7 +29,7 @@ class Pollutant(str, Enum):
     _ignore_ = "poll Pollutant"  # type:ignore[misc]
 
     Pollutant = vars()
-    for poll in client.all_pollutants:
+    for poll in client._pollutants_ids:
         Pollutant[poll] = poll
 
 
@@ -56,6 +56,8 @@ def root_options(
 
 @main.command(name="all")
 def download_all(
+    countries: List[Country] = typer.Option([], "--country", "-c"),
+    pollutants: List[Pollutant] = typer.Option([], "--pollutant", "-p"),
     path: Path = typer.Option(
         "data", exists=True, dir_okay=True, writable=True
     ),
@@ -65,9 +67,19 @@ def download_all(
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
 ):
-    """Download all pollutants for all countries"""
+    """Download all pollutants for all countries
+
+    \b
+    The -c/--country and -p/--pollutant allow to specify which data to download, e.g.
+    - download only Norwegian, Danish and Finish sites
+      airbase all -c NO -c DK -c FI
+    - download only SO2, PM10 and PM2.5 observations
+      airbase all -p SO2 -p PM10 -p PM2.5
+    """
 
     request = client.request(
+        countries or None,  # type:ignore[arg-type]
+        pollutants or None,  # type:ignore[arg-type]
         year_from=str(year),
         year_to=str(year),
         verbose=not quiet,

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -78,9 +78,9 @@ def download(
     \b
     The -c/--country and -p/--pollutant allow to specify which data to download, e.g.
     - download only Norwegian, Danish and Finish sites
-      airbase all -c NO -c DK -c FI
+      airbase download -c NO -c DK -c FI
     - download only SO2, PM10 and PM2.5 observations
-      airbase all -p SO2 -p PM10 -p PM2.5
+      airbase download -p SO2 -p PM10 -p PM2.5
     """
 
     request = client.request(

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -24,6 +24,9 @@ class Country(str, Enum):
     for country in client.countries:
         Country[country] = country
 
+    def __str__(self) -> str:
+        return self.name
+
 
 class Pollutant(str, Enum):
     _ignore_ = "poll Pollutant"  # type:ignore[misc]
@@ -31,6 +34,9 @@ class Pollutant(str, Enum):
     Pollutant = vars()
     for poll in client._pollutants_ids:
         Pollutant[poll] = poll
+
+    def __str__(self) -> str:
+        return self.name
 
 
 def version_callback(value: bool):  # pragma: no cover

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -54,8 +54,8 @@ def root_options(
     """Download Air Quality Data from the European Environment Agency (EEA)"""
 
 
-@main.command(name="all")
-def download_all(
+@main.command()
+def download(
     countries: List[Country] = typer.Option([], "--country", "-c"),
     pollutants: List[Pollutant] = typer.Option([], "--pollutant", "-p"),
     path: Path = typer.Option(
@@ -87,6 +87,32 @@ def download_all(
     request.download_to_directory(path, skip_existing=not overwrite)
 
 
+def deprecation_message(old: str, new: str):
+    old = typer.style(f"{__package__} {old}", fg=typer.colors.RED, bold=True)
+    new = typer.style(f"{__package__} {new}", fg=typer.colors.GREEN, bold=True)
+    typer.echo(
+        f"{old} has been deprecated and will be removed on v1. Use {new} all instead.",
+    )
+
+
+@main.command(name="all")
+def download_all(
+    countries: List[Country] = typer.Option([], "--country", "-c"),
+    pollutants: List[Pollutant] = typer.Option([], "--pollutant", "-p"),
+    path: Path = typer.Option(
+        "data", exists=True, dir_okay=True, writable=True
+    ),
+    year: int = typer.Option(date.today().year),
+    overwrite: bool = typer.Option(
+        False, "--overwrite", "-O", help="Re-download existing files."
+    ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
+):
+    """Download all pollutants for all countries (deprecated)"""
+    deprecation_message("all", "download")
+    download(countries, pollutants, path, year, overwrite, quiet)
+
+
 @main.command(name="country")
 def download_country(
     country: Country,
@@ -100,15 +126,9 @@ def download_country(
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
 ):
-    """Download specific pollutants for one country"""
-    request = client.request(
-        country,
-        pollutants or None,  # type:ignore[arg-type]
-        year_from=str(year),
-        year_to=str(year),
-        verbose=not quiet,
-    )
-    request.download_to_directory(path, skip_existing=not overwrite)
+    """Download specific pollutants for one country (deprecated)"""
+    deprecation_message("country", "download")
+    download([country], pollutants, path, year, overwrite, quiet)
 
 
 @main.command(name="pollutant")
@@ -124,12 +144,6 @@ def download_pollutant(
     ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="No progress-bar."),
 ):
-    """Download specific countries for one pollutant"""
-    request = client.request(
-        countries or None,  # type:ignore[arg-type]
-        pollutant,
-        year_from=str(year),
-        year_to=str(year),
-        verbose=not quiet,
-    )
-    request.download_to_directory(path, skip_existing=not overwrite)
+    """Download specific countries for one pollutant (deprecated)"""
+    deprecation_message("pollutant", "download")
+    download(countries, [pollutant], path, year, overwrite, quiet)

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -39,7 +39,7 @@ class Pollutant(str, Enum):
         return self.name
 
 
-def version_callback(value: bool):  # pragma: no cover
+def version_callback(value: bool):
     if not value:
         return
 

--- a/airbase/fetch.py
+++ b/airbase/fetch.py
@@ -56,7 +56,7 @@ def fetch_json(
 
     :param url: requested url
     :param timeout: maximum time to complete request (seconds)
-    :param encoding: text encoding used for decodding the response's body
+    :param encoding: text encoding used for decoding the response's body
 
     :return: decoded text from response's body as JSON
     """
@@ -100,12 +100,12 @@ async def fetcher(
     raise_for_status: bool = DEFAULT.raise_for_status,
     max_concurrent: int = DEFAULT.max_concurrent,
 ) -> AsyncIterator[str | Path]:
-    """Request multiple urls and write resquest text into individual paths
+    """Request multiple urls and write request text into individual paths
     it a `dict[url, path]` is provided, or return the decoded text from each request
     if only a `list[url]` is provided.
 
     :param urls: requested urls
-    :param encoding: text encoding used for decodding each response's body
+    :param encoding: text encoding used for decoding each response's body
     :param progress: show progress bar
     :param raise_for_status: Raise exceptions if download links
         return "bad" HTTP status codes. If False,
@@ -160,7 +160,7 @@ def fetch_unique_lines(
     """Request a list of url and return only the unique lines among all the responses
 
     :param urls: requested urls
-    :param encoding: text encoding used for decodding each response's body
+    :param encoding: text encoding used for decoding each response's body
     :param progress: show progress bar
     :param raise_for_status: Raise exceptions if download links
         return "bad" HTTP status codes. If False,
@@ -198,7 +198,7 @@ def fetch_to_file(
 
     :param urls: requested urls
     :param path: text file for all combined responses
-    :param encoding: text encoding used for decodding each response's body
+    :param encoding: text encoding used for decoding each response's body
     :param progress: show progress bar
     :param raise_for_status: Raise exceptions if download links
         return "bad" HTTP status codes. If False,
@@ -245,7 +245,7 @@ def fetch_to_directory(
     :param root: directory to write all responses
     :param bool skip_existing: Do not re-download url if the corresponding file
         is found in `root`
-    :param encoding: text encoding used for decodding each response's body
+    :param encoding: text encoding used for decoding each response's body
     :param progress: show progress bar
     :param raise_for_status: Raise exceptions if download links
         return "bad" HTTP status codes. If False,

--- a/airbase/summary/db.py
+++ b/airbase/summary/db.py
@@ -7,9 +7,9 @@ from contextlib import closing, contextmanager
 from pathlib import Path
 from typing import Iterator
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: no cover
     from importlib import resources
-else:
+else:  # pragma: no cover
     import importlib_resources as resources
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from airbase.cli import main
+
+runner = CliRunner()
+
+
+def test_download(tmp_path: Path):
+    country, year, pollutant, id = "NO", 2021, "NO2", 8
+    options = f"download --quiet --country {country} --pollutant {pollutant} --year {year} --path {tmp_path}"
+    result = runner.invoke(main, options.split())
+    assert result.exit_code == 0
+
+    files = tmp_path.glob(f"{country}_{id}_*_{year}_timeseries.csv")
+    assert list(files)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,10 @@
 import pytest
+from typer.testing import CliRunner
 
-from airbase.cli import Country, Pollutant
+from airbase import __version__
+from airbase.cli import Country, Pollutant, main
+
+runner = CliRunner()
 
 
 @pytest.mark.parametrize("country", Country)
@@ -11,3 +15,11 @@ def test_country(country: Country):
 @pytest.mark.parametrize("pollutant", Pollutant)
 def test_pollutant(pollutant: Pollutant):
     assert pollutant.name == pollutant.value == str(pollutant)
+
+
+@pytest.mark.parametrize("options", ("--version", "-V"))
+def test_version(options: str):
+    result = runner.invoke(main, options.split())
+    assert result.exit_code == 0
+    assert "airbase" in result.output
+    assert __version__ in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import pytest
+
+from airbase.cli import Country, Pollutant
+
+
+@pytest.mark.parametrize("country", Country)
+def test_country(country: Country):
+    assert country.name == country.value == str(country)
+
+
+@pytest.mark.parametrize("pollutant", Pollutant)
+def test_pollutant(pollutant: Pollutant):
+    assert pollutant.name == pollutant.value == str(pollutant)


### PR DESCRIPTION
At work we need to download all observations/sites for 6 different pollutants.
At the moment we invoke the CLI 6 times as follows:

``` bash
airbase pollutant SO2
airbase pollutant PM10
airbase pollutant O3
airbase pollutant NO2
airbase pollutant CO
airbase pollutant NO
airbase pollutant PM2.5
```

after merging this PR we'll be able to write

``` bash
airbase all -p SO2 -p PM10 -p O3 -p NO2 -p CO -p NO -p PM2.5
```

It will also be possible to restrict the download to specific countries on the same CLI sub-command, e.g. downloading the same pollutants only for Norwegian, Danish and Finish sites

``` bash
airbase all -p SO2 -p PM10 -p O3 -p NO2 -p CO -p NO -p PM2.5 -c NO -c DK -c FI
```

It might be possible to consolidate the other sub-commands (after a deprecation cycle), as their functionality is provided here.