### PR TITLE
single semaphore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
     args: [-l, "80"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v1.10.0
   hooks:
   - id: mypy
     exclude: '(docs/.*)|(setup\.py)'

--- a/tests/test_airbase.py
+++ b/tests/test_airbase.py
@@ -175,4 +175,4 @@ class TestAirbaseRequest:
 
         r = airbase.AirbaseRequest()
         r.download_metadata(path.name)
-        assert path.exists
+        assert path.exists()


### PR DESCRIPTION
Use a single semaphore to limit the number of open connections and open files.
Follow up to PR #47, close #46.