### PR TITLE
use Typer instad of Click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
     args: [-l, "80"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v1.10.0
   hooks:
   - id: mypy
     exclude: '(docs/.*)|(setup\.py)'

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     importlib_resources; python_version < "3.11"
     tqdm
     typing_extensions; python_version < "3.8"
-    click
+    typer >=0.9.1 
 packages = find:
 include_package_data = True
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
 from airbase.cli import main
 

--- a/tests/test_airbase.py
+++ b/tests/test_airbase.py
@@ -175,4 +175,4 @@ class TestAirbaseRequest:
 
         r = airbase.AirbaseRequest()
         r.download_metadata(path.name)
-        assert path.exists
+        assert path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
 from airbase import __version__
 from airbase.cli import Country, Pollutant, main


### PR DESCRIPTION
Since version 0.9.1 Typer correctly distinguishes between "CO" and "Co", see #42.
Replacing click with typer simplifies the CLI setup.