### PR TITLE
drop Python 3.7 support and enforce Python 3.8+ codding standards

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         prerelease: [false]
         include:
           - python: '3.13'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,12 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: "22.3.0"
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.9
   hooks:
-  - id: black
-    args: [-l, "80"]
+    - id: ruff-format # formatter
+    - id: ruff        # linter
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.10.0
   hooks:
   - id: mypy
     exclude: '(docs/.*)|(setup\.py)'
     additional_dependencies: [types-aiofiles, types-requests]
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
-    name: isort (python)
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.9
-  hooks:
-    - id: ruff # run the linter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
   hooks:
   - id: isort
     name: isort (python)
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.9
+  hooks:
+    - id: ruff # run the linter

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![CI/CD](https://github.com/JohnPaton/airbase/actions/workflows/cicd.yaml/badge.svg?branch=master)](https://github.com/JohnPaton/airbase/actions/workflows/cicd.yaml)
 [![Documentation Status](https://readthedocs.org/projects/airbase/badge/?version=latest)](https://airbase.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/format.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
 # 🌬 AirBase
 

--- a/airbase/__version__.py
+++ b/airbase/__version__.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 8):  # pragma: no cover
-    from importlib import metadata
-else:  # pragma: no cover
-    import importlib_metadata as metadata
+from importlib import metadata
 
 __version__: str | None
 try:

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -154,8 +154,8 @@ class AirbaseClient:
 
         if shortpl is not None:
             warnings.warn(
-                f"the shortpl option has been deprecated and will be removed on v1. "
-                f"Use client.request([client._pollutants_ids[p] for p in shortpl], ...) instead.",
+                "the shortpl option has been deprecated and will be removed on v1. "
+                "Use client.request([client._pollutants_ids[p] for p in shortpl], ...) instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -330,9 +330,7 @@ class AirbaseRequest:
 
         if self.verbose:
             print(
-                "Generated {:,} CSV links ready for downloading".format(
-                    len(self._csv_links)
-                ),
+                f"Generated {len(self._csv_links):,} CSV links ready for downloading",
                 file=sys.stderr,
             )
 

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -4,11 +4,7 @@ import sys
 import warnings
 from datetime import datetime
 from pathlib import Path
-
-if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import TypedDict
-else:  # pragma: no cover
-    from typing_extensions import TypedDict
+from typing import TypedDict
 
 from .fetch import (
     fetch_text,

--- a/airbase/resources.py
+++ b/airbase/resources.py
@@ -1,4 +1,5 @@
 """Global variables for URL templating"""
+
 import datetime
 
 E1A_SUMMARY_URL = "http://discomap.eea.europa.eu/map/fme/E1a/summaryE1a.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,10 @@ line-length = 80
 extend-exclude = ["docs", "scripts", "build"]
 
 [tool.ruff.lint]
-select = ["F", "UP"]
+select = ["E", "W", "F", "UP"]
+ignore = [
+    "E501", # https://docs.astral.sh/ruff/rules/line-too-long/
+]
 
 [tool.ruff.lint.per-file-ignores]
 "cli.py" = [ # typer needs typing.Optional and typing.List

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ line-length = 80
 extend-exclude = ["docs", "scripts", "build"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "UP"]
+select = ["E", "W", "F", "I", "UP"]
 ignore = [
     "E501", # https://docs.astral.sh/ruff/rules/line-too-long/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,17 @@ show_missing = true
 
 [tool.black]
 line-length = 80
-target-version = ["py37"]
+target-version = ["py38"]
 
 [tool.isort]
 line_length = 80
-py_version = "37"
+py_version = "38"
 profile = "black"
 src_paths = ["airbase", "tests"]
 extend_skip = ["scripts"]
 
 [tool.mypy]
+python_version = "3.8"
 warn_unused_configs = true
 warn_unused_ignores = false
 warn_no_return = true
@@ -41,7 +42,7 @@ warn_unreachable = true
 show_error_codes = true
 pretty = true
 sqlite_cache = true
-exclude = "docs|scripts"
+exclude = "docs|scripts|build"
 
 [[tool.mypy.overrides]]
 module = ["tqdm"]
@@ -50,7 +51,7 @@ ignore_missing_imports = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, lint, docs, integration
+envlist = py38, py39, py310, py311, py312, lint, docs, integration
 skip_missing_interpreters = True
 isolated_build = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,20 @@ profile = "black"
 src_paths = ["airbase", "tests"]
 extend_skip = ["scripts"]
 
+[tool.ruff]
+target-version = "py38"
+line-length = 80
+extend-exclude = ["docs", "scripts", "build"]
+
+[tool.ruff.lint]
+select = ["UP"]
+
+[tool.ruff.lint.per-file-ignores]
+"cli.py" = [ # typer needs typing.Optional and typing.List
+    "UP006", # https://docs.astral.sh/ruff/rules/non-pep585-annotation/
+    "UP007", # https://docs.astral.sh/ruff/rules/non-pep604-annotation/
+]
+
 [tool.mypy]
 python_version = "3.8"
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,6 @@ skip_covered = true
 skip_empty = true
 show_missing = true
 
-[tool.black]
-line-length = 80
-target-version = ["py38"]
-
-[tool.isort]
-line_length = 80
-py_version = "38"
-profile = "black"
-src_paths = ["airbase", "tests"]
-extend_skip = ["scripts"]
-
 [tool.ruff]
 target-version = "py38"
 line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ line-length = 80
 extend-exclude = ["docs", "scripts", "build"]
 
 [tool.ruff.lint]
-select = ["UP"]
+select = ["F", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "cli.py" = [ # typer needs typing.Optional and typing.List

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     aiofiles
     importlib_resources; python_version < "3.11"
     tqdm
-    typing_extensions; python_version < "3.8"
     typer >=0.9.1 
 packages = find:
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -21,7 +20,7 @@ classifiers =
     Topic :: Scientific/Engineering :: Atmospheric Science
 
 [options]
-python_requires = >=3.7,<4
+python_requires = >=3.8,<4
 install_requires =
     aiohttp; python_version < "3.12"
     aiohttp >= 3.9.0; python_version >= "3.12"

--- a/tests/test_airbase.py
+++ b/tests/test_airbase.py
@@ -156,7 +156,7 @@ class TestAirbaseRequest:
         assert header == header_expected
 
         # make sure header only there once
-        is_header = (l.strip() == header_expected for l in lines)
+        is_header = (line.strip() == header_expected for line in lines)
         assert sum(is_header) == 1
 
     def test_download_metadata(self, tmp_path: Path):

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -134,7 +134,9 @@ def test_fetch_to_file(tmp_path: Path, csv_urls: dict[str, str]):
     assert path.exists()
 
     # drop the header and compare data rows
-    rows = lambda text: text.splitlines()[1:]
+    def rows(text: str) -> list[str]:
+        return text.splitlines()[1:]
+
     data_on_file = rows(path.read_text())
     data_rows = list(
         itertools.chain.from_iterable(rows(text) for text in csv_urls.values())


### PR DESCRIPTION
- drop Python 3.7 support
- enforce code standards for Python 3.8+ using ruff