### PR TITLE
Bugfix: Don't update uv.lock inside CI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 12 1 * *'  # On the first day of the month
   pull_request:
 
+env:
+  UV_FROZEN: "true""
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -55,6 +58,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-project
         name: Setup project
+      - run: git diff --exit-code
+        name: Assert workdir is clean
       - run: |
           uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is causing tags the working dir to be dirty, so even builds for tags are building dev versions. See [here](https://github.com/JohnPaton/airbase/actions/runs/12163540294/job/33923078632#step:4:16).