### PR TITLE
chain CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Commands:
   historical  Historical Airbase data delivered between 2002 and 2012...
   verified    Verified data (E1a) from 2013 to 2023 reported by countries...
   unverified  Unverified data transmitted continuously...
+  metadata    Download station metadata.
 ```
 
 ### Historical data delivered between 2002 and 2012
@@ -135,12 +136,7 @@ Options:
   -F, --aggregation-type, --frequency [hourly|daily|other]
                                   Only hourly data, daily data or other
                                   aggregation frequency.
-  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/historical]
-  -n, --dry-run, --summary        Total download files/size, nothing will be
-                                  downloaded.
-  -O, --overwrite                 Re-download existing files.
-  -q, --quiet                     No progress-bar.
   --help                          Show this message and exit.
 ```
 
@@ -170,7 +166,6 @@ Options:
   -F, --aggregation-type, --frequency [hourly|daily|other]
                                   Only hourly data, daily data or other
                                   aggregation frequency.
-  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/verified]
   --help                          Show this message and exit.
 ```
@@ -201,9 +196,23 @@ Options:
   -F, --aggregation-type, --frequency [hourly|daily|other]
                                   Only hourly data, daily data or other
                                   aggregation frequency.
-  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/unverified]
   --help                          Show this message and exit.
+```
+
+### Station metadata
+
+``` console
+$ airbase metadata --help
+Usage: airbase metadata [OPTIONS] [PATH]
+
+  Download station metadata.
+
+Arguments:
+  [PATH]  [default: data/metadata.csv]
+
+Options:
+  --help  Show this message and exit.
 ```
 
 ## 🛣 Roadmap

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Usage: airbase [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
   Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
   or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
   - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
-    to different (existing) paths in order to avoid filename collisions
+    into different paths in order to avoid filename collisions
     airbase --no-subdir \
       verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
       verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
@@ -107,7 +107,7 @@ Commands:
   historical  Historical Airbase data delivered between 2002 and 2012...
   verified    Verified data (E1a) from 2013 to 2023 reported by countries...
   unverified  Unverified data transmitted continuously...
-  metadata    Download station metadata.
+  metadata    Download station metadata into `PATH/metadata.csv`.
 ```
 
 ### Historical data delivered between 2002 and 2012
@@ -204,15 +204,22 @@ Options:
 
 ``` console
 $ airbase metadata --help
-Usage: airbase metadata [OPTIONS] [PATH]
+Usage: airbase metadata [OPTIONS]
 
-  Download station metadata.
+  Download station metadata into `PATH/metadata.csv`.
 
-Arguments:
-  [PATH]  [default: data/metadata.csv]
+  Use chan notation to donwload metadata and observations, e.g.
+  - donwload station metadata and hourly PM10 and PM2.5 observations
+    from sites in Oslo into into different paths
+      airbase --quiet --no-subdir \
+        historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \
+        verified   --path data/verified   -F hourly -p PM10 -p PM2.5 -C Oslo \
+        unverified --path data/unverified -F hourly -p PM10 -p PM2.5 -C Oslo \
+        metadata   --path data/
 
 Options:
-  --help  Show this message and exit.
+  --path PATH  [default: data]
+  --help       Show this message and exit.
 ```
 
 ## 🛣 Roadmap

--- a/README.md
+++ b/README.md
@@ -81,24 +81,24 @@ Usage: airbase historical [OPTIONS]
   Historical Airbase data delivered between 2002 and 2012 before Air Quality
   Directive 2008/50/EC entered into force.
 
-  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+  or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
   - download only Norwegian, Danish and Finish sites
     airbase historical -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase historical -p SO2 -p PM10 -p PM2.5
-
-  Use -C/--city to further restrict the download to specific cities, e.g.
   - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase historical -C Valletta -c MT -p PM10 -p PM2.5
+    airbase historical -C Valletta -p PM10 -p PM2.5
 
 Options:
   -c, --country [AD|AL|AT|...]
   -p, --pollutant [k|V|NT|...]
-  -C, --city TEXT                 only from selected <cities>
+  -C, --city TEXT                 Only from selected <cities> (--country
+                                  option will be ignored).
   -F, --aggregation-type, --frequency [hourly|daily|other]
-                                  only hourly data, daily data or other
-                                  aggregation frequency
-  -M, --metadata                  download station metadata
+                                  Only hourly data, daily data or other
+                                  aggregation frequency.
+  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/historical]
   -n, --dry-run, --summary        Total download files/size, nothing will be
                                   downloaded.
@@ -116,24 +116,24 @@ Usage: airbase verified [OPTIONS]
   Verified data (E1a) from 2013 to 2023 reported by countries by 30 September
   each year for the previous year.
 
-  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+  or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
   - download only Norwegian, Danish and Finish sites
     airbase verified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase verified -p SO2 -p PM10 -p PM2.5
-
-  Use -C/--city to further restrict the download to specific cities, e.g.
   - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase verified -C Valletta -c MT -p PM10 -p PM2.5
+    airbase verified -C Valletta -p PM10 -p PM2.5
 
 Options:
   -c, --country [AD|AL|AT|...]
   -p, --pollutant [k|V|NT|...]
-  -C, --city TEXT                 only from selected <cities>
+  -C, --city TEXT                 Only from selected <cities> (--country
+                                  option will be ignored).
   -F, --aggregation-type, --frequency [hourly|daily|other]
-                                  only hourly data, daily data or other
-                                  aggregation frequency
-  -M, --metadata                  download station metadata
+                                  Only hourly data, daily data or other
+                                  aggregation frequency.
+  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/verified]
   -n, --dry-run, --summary        Total download files/size, nothing will be
                                   downloaded.
@@ -151,24 +151,24 @@ Usage: airbase unverified [OPTIONS]
   Unverified data transmitted continuously (Up-To-Date/UTD/E2a) data from the
   beginning of 2024.
 
-  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+  or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
   - download only Norwegian, Danish and Finish sites
     airbase unverified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase unverified -p SO2 -p PM10 -p PM2.5
-
-  Use -C/--city to further restrict the download to specific cities, e.g.
   - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase unverified -C Valletta -c MT -p PM10 -p PM2.5
+    airbase unverified -C Valletta -p PM10 -p PM2.5
 
 Options:
   -c, --country [AD|AL|AT|...]
   -p, --pollutant [k|V|NT|...]
-  -C, --city TEXT                 only from selected <cities>
+  -C, --city TEXT                 Only from selected <cities> (--country
+                                  option will be ignored).
   -F, --aggregation-type, --frequency [hourly|daily|other]
-                                  only hourly data, daily data or other
-                                  aggregation frequency
-  -M, --metadata                  download station metadata
+                                  Only hourly data, daily data or other
+                                  aggregation frequency.
+  -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/unverified]
   -n, --dry-run, --summary        Total download files/size, nothing will be
                                   downloaded.

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ Usage: airbase metadata [OPTIONS]
 
   Download station metadata into `PATH/metadata.csv`.
 
-  Use chan notation to donwload metadata and observations, e.g.
-  - donwload station metadata and hourly PM10 and PM2.5 observations
+  Use chan notation to download metadata and observations, e.g.
+  - download station metadata and hourly PM10 and PM2.5 observations
     from sites in Oslo into into different paths
       airbase --quiet --no-subdir \
         historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ Writing metadata to data/metadata.csv...
 
 ## 🚆 Command line interface
 
+``` console
+$ airbase --help
+Usage: airbase [OPTIONS] COMMAND [ARGS]...
+
+  Download Air Quality Data from the European Environment Agency (EEA)
+
+Options:
+  -V, --version
+  -n, --dry-run, --summary  Total download files/size, nothing will be
+                            downloaded.
+  --subdir / --no-subdir    Download files for different counties to different
+                            sub directories.  [default: subdir]
+  -O, --overwrite           Re-download existing files.
+  -q, --quiet               No progress-bar.
+  --help                    Show this message and exit.
+
+Commands:
+  historical  Historical Airbase data delivered between 2002 and 2012...
+  verified    Verified data (E1a) from 2013 to 2023 reported by countries...
+  unverified  Unverified data transmitted continuously...
+```
+
 ### Historical data delivered between 2002 and 2012
 
 ``` console
@@ -83,7 +105,7 @@ Usage: airbase historical [OPTIONS]
 
   Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
   or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-  - download only Norwegian, Danish and Finish sites
+  - download only from Norwegian, Danish and Finish sites
     airbase historical -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase historical -p SO2 -p PM10 -p PM2.5
@@ -118,7 +140,7 @@ Usage: airbase verified [OPTIONS]
 
   Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
   or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-  - download only Norwegian, Danish and Finish sites
+  - download only from Norwegian, Danish and Finish sites
     airbase verified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase verified -p SO2 -p PM10 -p PM2.5
@@ -135,10 +157,6 @@ Options:
                                   aggregation frequency.
   -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/verified]
-  -n, --dry-run, --summary        Total download files/size, nothing will be
-                                  downloaded.
-  -O, --overwrite                 Re-download existing files.
-  -q, --quiet                     No progress-bar.
   --help                          Show this message and exit.
 ```
 
@@ -153,7 +171,7 @@ Usage: airbase unverified [OPTIONS]
 
   Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
   or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-  - download only Norwegian, Danish and Finish sites
+  - download only from Norwegian, Danish and Finish sites
     airbase unverified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase unverified -p SO2 -p PM10 -p PM2.5
@@ -170,10 +188,6 @@ Options:
                                   aggregation frequency.
   -M, --metadata                  Download station metadata.
   --path PATH                     [default: data/unverified]
-  -n, --dry-run, --summary        Total download files/size, nothing will be
-                                  downloaded.
-  -O, --overwrite                 Re-download existing files.
-  -q, --quiet                     No progress-bar.
   --help                          Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,24 @@ Writing metadata to data/metadata.csv...
 
 ``` console
 $ airbase --help
-Usage: airbase [OPTIONS] COMMAND [ARGS]...
+Usage: airbase [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
   Download Air Quality Data from the European Environment Agency (EEA)
+
+  Use -n/--dry-run/--summary and -q/--quiet to request the number of files and
+  estimated download size without downloading the observations, e.g
+  - total download files/size for hourly verified and unverified observations
+    airbase --quiet --summary \
+      verified -F hourly \
+      unverified -F hourly
+
+  Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+  or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
+  - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
+    to different (existing) paths in order to avoid filename collisions
+    airbase --no-subdir \
+      verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
+      verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
 
 Options:
   -V, --version
@@ -109,8 +124,8 @@ Usage: airbase historical [OPTIONS]
     airbase historical -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase historical -p SO2 -p PM10 -p PM2.5
-  - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase historical -C Valletta -p PM10 -p PM2.5
+  - download only PM10 and PM2.5 observations from sites in Oslo
+    airbase historical -p PM10 -p PM2.5 -C Oslo
 
 Options:
   -c, --country [AD|AL|AT|...]
@@ -144,8 +159,8 @@ Usage: airbase verified [OPTIONS]
     airbase verified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase verified -p SO2 -p PM10 -p PM2.5
-  - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase verified -C Valletta -p PM10 -p PM2.5
+  - download only PM10 and PM2.5 observations from sites in Oslo
+    airbase verified -p PM10 -p PM2.5 -C Oslo
 
 Options:
   -c, --country [AD|AL|AT|...]
@@ -175,8 +190,8 @@ Usage: airbase unverified [OPTIONS]
     airbase unverified -c NO -c DK -c FI
   - download only SO2, PM10 and PM2.5 observations
     airbase unverified -p SO2 -p PM10 -p PM2.5
-  - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-    airbase unverified -C Valletta -p PM10 -p PM2.5
+  - download only PM10 and PM2.5 observations from sites in Oslo
+    airbase unverified -p PM10 -p PM2.5 -C Oslo
 
 Options:
   -c, --country [AD|AL|AT|...]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Commands:
   historical  Historical Airbase data delivered between 2002 and 2012...
   verified    Verified data (E1a) from 2013 to 2023 reported by countries...
   unverified  Unverified data transmitted continuously...
-  metadata    Download station metadata into `PATH/metadata.csv`.
+  metadata    Download station metadata.
 ```
 
 ### Historical data delivered between 2002 and 2012
@@ -206,7 +206,7 @@ Options:
 $ airbase metadata --help
 Usage: airbase metadata [OPTIONS]
 
-  Download station metadata into `PATH/metadata.csv`.
+  Download station metadata.
 
   Use chan notation to download metadata and observations, e.g.
   - download station metadata and hourly PM10 and PM2.5 observations
@@ -219,6 +219,7 @@ Usage: airbase metadata [OPTIONS]
 
 Options:
   --path PATH  [default: data]
+  --metadata   Station metadata. [default: PATH/metadata.csv]
   --help       Show this message and exit.
 ```
 

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -245,7 +245,9 @@ class AirbaseRequest:
         )
         self.session.raise_for_status = raise_for_status
         asyncio.run(
-            download(self.session, info, dir, overwrite=not skip_existing)
+            download(
+                "PARQUET", self.session, info, dir, overwrite=not skip_existing
+            )
         )
 
     def download_metadata(self, filepath: str | Path) -> None:
@@ -265,6 +267,4 @@ class AirbaseRequest:
 
         if self.verbose:
             print(f"Writing metadata to {filepath}...", file=sys.stderr)
-        asyncio.run(
-            download(self.session, frozenset(), filepath, metadata_only=True)
-        )
+        asyncio.run(download("METADATA", self.session, frozenset(), filepath))

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -212,7 +212,7 @@ class AirbaseRequest:
         else:  # pragma:no cover
             assert_never(poll)
 
-        self.verbose = verbose
+        self.session.progress = self.verbose = verbose
 
     def download(
         self,
@@ -243,13 +243,12 @@ class AirbaseRequest:
             countries=self.counties,
             pollutants=self.pollutants,
         )
+        self.session.raise_for_status = raise_for_status
         asyncio.run(
             download(
                 info,
                 dir,
                 overwrite=not skip_existing,
-                quiet=not self.verbose,
-                raise_for_status=raise_for_status,
                 session=self.session,
             )
         )

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -245,12 +245,7 @@ class AirbaseRequest:
         )
         self.session.raise_for_status = raise_for_status
         asyncio.run(
-            download(
-                info,
-                dir,
-                overwrite=not skip_existing,
-                session=self.session,
-            )
+            download(self.session, info, dir, overwrite=not skip_existing)
         )
 
     def download_metadata(self, filepath: str | Path) -> None:
@@ -268,10 +263,8 @@ class AirbaseRequest:
                 f"{filepath.parent.resolve()} does not exist."
             )
 
-        async def fetch_metadata():
-            async with self.session:
-                await self.session.download_metadata(filepath)
-
         if self.verbose:
             print(f"Writing metadata to {filepath}...", file=sys.stderr)
-        asyncio.run(fetch_metadata())
+        asyncio.run(
+            download(self.session, frozenset(), filepath, metadata_only=True)
+        )

--- a/airbase/airbase.py
+++ b/airbase/airbase.py
@@ -11,7 +11,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import assert_never
 
-from .parquet_api import Dataset, Session, download
+from .parquet_api import Dataset, Session, download, request_info
 from .summary import DB
 
 
@@ -238,12 +238,15 @@ class AirbaseRequest:
         if not dir.is_dir():
             raise NotADirectoryError(f"{dir.resolve()} is not a directory.")
 
+        info = request_info(
+            self.source,
+            countries=self.counties,
+            pollutants=self.pollutants,
+        )
         asyncio.run(
             download(
-                self.source,
+                info,
                 dir,
-                countries=self.counties,
-                pollutants=self.pollutants,
                 overwrite=not skip_existing,
                 quiet=not self.verbose,
                 raise_for_status=raise_for_status,

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -82,6 +82,10 @@ def downloader(
     async def download_(reqests: set[Request]):
         for req in reqests:
             typer.echo(req.name)
+            if req.metadata:
+                req.path.parent.mkdir(parents=True, exist_ok=True)
+            elif not summary_only:
+                req.path.mkdir(parents=True, exist_ok=True)
             await download(
                 session,
                 req.info,
@@ -197,7 +201,7 @@ MetadataOption: TypeAlias = Annotated[
     bool, typer.Option("-M", "--metadata", help="Download station metadata.")
 ]
 PathOption: TypeAlias = Annotated[
-    Path, typer.Option("--path", exists=True, dir_okay=True, writable=True)
+    Path, typer.Option("--path", dir_okay=True, writable=True)
 ]
 
 
@@ -308,9 +312,9 @@ def metadata(
     ctx: typer.Context,
     path: Annotated[
         Path,
-        typer.Argument(file_okay=True, dir_okay=True, writable=True),
+        typer.Argument(dir_okay=True, writable=True),
     ],
 ):
     """Download station metadata."""
     obj: set[Request] = ctx.ensure_object(set)
-    obj.add(Request(ctx.command_path, frozenset(), path, True))
+    obj.add(Request(ctx.command_path, frozenset(), path / "metadata.csv", True))

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -13,7 +13,7 @@ else:
 import typer
 
 from . import __version__
-from .parquet_api import AggregationType, Dataset, download
+from .parquet_api import AggregationType, Dataset, download, request_info
 from .summary import DB
 
 main = typer.Typer(add_completion=False, no_args_is_help=True)
@@ -157,14 +157,17 @@ def historical(
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
       airbase historical -C Valletta -p PM10 -p PM2.5
     """
+    info = request_info(
+        Dataset.Historical,
+        countries=set(map(str, countries)),
+        pollutants=set(map(str, pollutants)),
+        cities=set(cities),
+        frequency=None if frequency is None else frequency.aggregation_type,
+    )
     asyncio.run(
         download(
-            Dataset.Historical,
+            info,
             path,
-            countries=frozenset(map(str, countries)),
-            pollutants=frozenset(map(str, pollutants)),
-            cities=frozenset(cities),
-            frequency=None if frequency is None else frequency.aggregation_type,
             metadata=metadata,
             summary_only=summary_only,
             country_subdir=country_subdir,
@@ -200,14 +203,17 @@ def verified(
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
       airbase verified -C Valletta -p PM10 -p PM2.5
     """
+    info = request_info(
+        Dataset.Verified,
+        countries=set(map(str, countries)),
+        pollutants=set(map(str, pollutants)),
+        cities=set(cities),
+        frequency=None if frequency is None else frequency.aggregation_type,
+    )
     asyncio.run(
         download(
-            Dataset.Verified,
+            info,
             path,
-            countries=frozenset(map(str, countries)),
-            pollutants=frozenset(map(str, pollutants)),
-            cities=frozenset(cities),
-            frequency=None if frequency is None else frequency.aggregation_type,
             metadata=metadata,
             summary_only=summary_only,
             country_subdir=country_subdir,
@@ -243,14 +249,17 @@ def unverified(
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
       airbase unverified -C Valletta -p PM10 -p PM2.5
     """
+    info = request_info(
+        Dataset.Unverified,
+        countries=set(map(str, countries)),
+        pollutants=set(map(str, pollutants)),
+        cities=set(cities),
+        frequency=None if frequency is None else frequency.aggregation_type,
+    )
     asyncio.run(
         download(
-            Dataset.Unverified,
+            info,
             path,
-            countries=frozenset(map(str, countries)),
-            pollutants=frozenset(map(str, pollutants)),
-            cities=frozenset(cities),
-            frequency=None if frequency is None else frequency.aggregation_type,
             metadata=metadata,
             summary_only=summary_only,
             country_subdir=country_subdir,

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -92,6 +92,13 @@ def print_version(value: bool):
     raise typer.Exit()
 
 
+class SharedOptions(NamedTuple):
+    summary_only: bool
+    country_subdir: bool
+    overwrite: bool
+    quiet: bool
+
+
 def result_callback(
     requests: list[Optional[Request]],
     *,
@@ -176,6 +183,12 @@ def callback(
         verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \\
         verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
     """
+    ctx.obj = SharedOptions(
+        summary_only=summary_only,
+        country_subdir=country_subdir,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
 
 
 CountryList: TypeAlias = Annotated[

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -13,7 +13,13 @@ else:
 import typer
 
 from . import __version__
-from .parquet_api import AggregationType, Dataset, download, request_info
+from .parquet_api import (
+    AggregationType,
+    Dataset,
+    Session,
+    download,
+    request_info,
+)
 from .summary import DB
 
 main = typer.Typer(add_completion=False, no_args_is_help=True)
@@ -60,7 +66,7 @@ class SharedOptions(NamedTuple):
     summary_only: bool
     country_subdir: bool
     overwrite: bool
-    quiet: bool
+    session: Session
 
 
 def version_callback(value: bool):
@@ -104,7 +110,15 @@ def callback(
     ] = False,
 ):
     """Download Air Quality Data from the European Environment Agency (EEA)"""
-    ctx.obj = SharedOptions(summary_only, country_subdir, overwrite, quiet)
+    ctx.obj = SharedOptions(
+        summary_only,
+        country_subdir,
+        overwrite,
+        Session(
+            progress=not quiet,
+            raise_for_status=False,
+        ),
+    )
 
 
 CountryList: TypeAlias = Annotated[
@@ -178,7 +192,7 @@ def historical(
             summary_only=ctx.obj.summary_only,
             country_subdir=ctx.obj.country_subdir,
             overwrite=ctx.obj.overwrite,
-            quiet=ctx.obj.quiet,
+            session=ctx.obj.session,
         )
     )
 
@@ -221,7 +235,7 @@ def verified(
             summary_only=ctx.obj.summary_only,
             country_subdir=ctx.obj.country_subdir,
             overwrite=ctx.obj.overwrite,
-            quiet=ctx.obj.quiet,
+            session=ctx.obj.session,
         )
     )
 
@@ -264,6 +278,6 @@ def unverified(
             summary_only=ctx.obj.summary_only,
             country_subdir=ctx.obj.country_subdir,
             overwrite=ctx.obj.overwrite,
-            quiet=ctx.obj.quiet,
+            session=ctx.obj.session,
         )
     )

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -203,9 +203,6 @@ FrequencyOption: TypeAlias = Annotated[
         help="Only hourly data, daily data or other aggregation frequency.",
     ),
 ]
-MetadataOption: TypeAlias = Annotated[
-    bool, typer.Option("-M", "--metadata", help="Download station metadata.")
-]
 PathOption: TypeAlias = Annotated[
     Path, typer.Option("--path", dir_okay=True, writable=True)
 ]
@@ -326,9 +323,18 @@ def unverified(
 def metadata(
     ctx: typer.Context,
     path: PathOption = Path("data"),
+    metadata: Annotated[
+        Optional[Path],
+        typer.Option(
+            file_okay=True,
+            writable=True,
+            metavar="",
+            help="Station metadata. [default: PATH/metadata.csv]",
+        ),
+    ] = None,
 ):
     """
-    Download station metadata into `PATH/metadata.csv`.
+    Download station metadata.
 
     \b
     Use chan notation to download metadata and observations, e.g.
@@ -343,6 +349,6 @@ def metadata(
     if not ctx.ensure_object(SharedOptions).summary_only:
         path.mkdir(parents=True, exist_ok=True)
 
-    return Request(
-        "METADATA", ctx.command_path, frozenset(), path / "metadata.csv"
-    )
+    if metadata is None:
+        metadata = path / "metadata.csv"
+    return Request("METADATA", ctx.command_path, frozenset(), metadata)

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -319,8 +319,8 @@ def metadata(
     Download station metadata into `PATH/metadata.csv`.
 
     \b
-    Use chan notation to donwload metadata and observations, e.g.
-    - donwload station metadata and hourly PM10 and PM2.5 observations
+    Use chan notation to download metadata and observations, e.g.
+    - download station metadata and hourly PM10 and PM2.5 observations
       from sites in Oslo into into different paths
         airbase --no-subdir \\
           historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \\

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -97,7 +97,7 @@ def downloader(
     asyncio.run(download_(reqests))
 
 
-def version_callback(value: bool):
+def print_version(value: bool):
     if not value:
         return
 
@@ -110,7 +110,7 @@ def callback(
     ctx: typer.Context,
     version: Annotated[
         Optional[bool],
-        typer.Option("--version", "-V", callback=version_callback),
+        typer.Option("--version", "-V", callback=print_version),
     ] = None,
     summary_only: Annotated[
         bool,

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -93,7 +93,7 @@ def print_version(value: bool):
 
 
 def result_callback(
-    requests: list[Request],
+    requests: list[Optional[Request]],
     *,
     summary_only: bool,
     country_subdir: bool,
@@ -118,7 +118,7 @@ def result_callback(
 
     asyncio.run(
         downloader(
-            set(requests),
+            set(req for req in requests if isinstance(req, Request)),
             Session(progress=not quiet, raise_for_status=False),
         )
     )

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -84,7 +84,11 @@ PollutantList: TypeAlias = Annotated[
 ]
 CityList: TypeAlias = Annotated[
     list[str],
-    typer.Option("-C", "--city", help="Only from selected <cities>."),
+    typer.Option(
+        "-C",
+        "--city",
+        help="Only from selected <cities> (--country option will be ignored).",
+    ),
 ]
 FrequencyOption: TypeAlias = Annotated[
     Optional[Frequency],
@@ -144,16 +148,14 @@ def historical(
     Historical Airbase data delivered between 2002 and 2012 before Air Quality Directive 2008/50/EC entered into force.
 
     \b
-    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+    or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
     - download only Norwegian, Danish and Finish sites
       airbase historical -c NO -c DK -c FI
     - download only SO2, PM10 and PM2.5 observations
       airbase historical -p SO2 -p PM10 -p PM2.5
-
-    \b
-    Use -C/--city to further restrict the download to specific cities, e.g.
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-      airbase historical -C Valletta -c MT -p PM10 -p PM2.5
+      airbase historical -C Valletta -p PM10 -p PM2.5
     """
     asyncio.run(
         download(
@@ -189,16 +191,14 @@ def verified(
     Verified data (E1a) from 2013 to 2023 reported by countries by 30 September each year for the previous year.
 
     \b
-    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+    or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
     - download only Norwegian, Danish and Finish sites
       airbase verified -c NO -c DK -c FI
     - download only SO2, PM10 and PM2.5 observations
       airbase verified -p SO2 -p PM10 -p PM2.5
-
-    \b
-    Use -C/--city to further restrict the download to specific cities, e.g.
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-      airbase verified -C Valletta -c MT -p PM10 -p PM2.5
+      airbase verified -C Valletta -p PM10 -p PM2.5
     """
     asyncio.run(
         download(
@@ -234,16 +234,14 @@ def unverified(
     Unverified data transmitted continuously (Up-To-Date/UTD/E2a) data from the beginning of 2024.
 
     \b
-    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+    or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
     - download only Norwegian, Danish and Finish sites
       airbase unverified -c NO -c DK -c FI
     - download only SO2, PM10 and PM2.5 observations
       airbase unverified -p SO2 -p PM10 -p PM2.5
-
-    \b
-    Use -C/--city to further restrict the download to specific cities, e.g.
     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-      airbase unverified -C Valletta -c MT -p PM10 -p PM2.5
+      airbase unverified -C Valletta -p PM10 -p PM2.5
     """
     asyncio.run(
         download(

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -171,7 +171,7 @@ def callback(
     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
     or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
     - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
-      to different (existing) paths in order to avoid filename collisions
+      into different paths in order to avoid filename collisions
       airbase --no-subdir \\
         verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \\
         verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
@@ -310,13 +310,22 @@ def unverified(
     return Request(name, frozenset(info), path)
 
 
-@main.command(no_args_is_help=True)
+@main.command(no_args_is_help=False)
 def metadata(
     ctx: typer.Context,
-    path: Annotated[
-        Path,
-        typer.Argument(dir_okay=True, writable=True),
-    ],
+    path: PathOption = Path("data"),
 ):
-    """Download station metadata into `PATH/metadata.csv`."""
+    """
+    Download station metadata into `PATH/metadata.csv`.
+
+    \b
+    Use chan notation to donwload metadata and observations, e.g.
+    - donwload station metadata and hourly PM10 and PM2.5 observations
+      from sites in Oslo into into different paths
+        airbase --no-subdir \\
+          historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \\
+          verified   --path data/verified   -F hourly -p PM10 -p PM2.5 -C Oslo \\
+          unverified --path data/unverified -F hourly -p PM10 -p PM2.5 -C Oslo \\
+          metadata   --path data/
+    """
     return Request(ctx.command_path, frozenset(), path / "metadata.csv")

--- a/airbase/cli.py
+++ b/airbase/cli.py
@@ -77,12 +77,6 @@ class Request(NamedTuple):
     def metadata(self) -> bool:
         return self.path.name == "metadata.csv"
 
-    @property
-    def root_path(self) -> Path:
-        if self.metadata:
-            return self.path.parent
-        return self.path
-
 
 def print_version(value: bool):
     if not value:
@@ -111,8 +105,6 @@ def result_callback(
     async def downloader(requests: set[Request], session: Session):
         for req in requests:
             typer.echo(req.name)
-            if not summary_only:
-                req.root_path.mkdir(parents=True, exist_ok=True)
             await download(
                 session,
                 req.info,
@@ -246,6 +238,9 @@ def historical(
     - download only PM10 and PM2.5 observations from sites in Oslo
       airbase historical -p PM10 -p PM2.5 -C Oslo
     """
+    if not ctx.ensure_object(SharedOptions).summary_only:
+        path.mkdir(parents=True, exist_ok=True)
+
     name = f"{ctx.command_path} {frequency}" if frequency else ctx.command_path
     info = request_info(
         Dataset.Historical,
@@ -279,6 +274,9 @@ def verified(
     - download only PM10 and PM2.5 observations from sites in Oslo
       airbase verified -p PM10 -p PM2.5 -C Oslo
     """
+    if not ctx.ensure_object(SharedOptions).summary_only:
+        path.mkdir(parents=True, exist_ok=True)
+
     name = f"{ctx.command_path} {frequency}" if frequency else ctx.command_path
     info = request_info(
         Dataset.Verified,
@@ -312,6 +310,9 @@ def unverified(
     - download only PM10 and PM2.5 observations from sites in Oslo
       airbase unverified -p PM10 -p PM2.5 -C Oslo
     """
+    if not ctx.ensure_object(SharedOptions).summary_only:
+        path.mkdir(parents=True, exist_ok=True)
+
     name = f"{ctx.command_path} {frequency}" if frequency else ctx.command_path
     info = request_info(
         Dataset.Unverified,
@@ -341,4 +342,7 @@ def metadata(
           unverified --path data/unverified -F hourly -p PM10 -p PM2.5 -C Oslo \\
           metadata   --path data/
     """
+    if not ctx.ensure_object(SharedOptions).summary_only:
+        path.mkdir(parents=True, exist_ok=True)
+
     return Request(ctx.command_path, frozenset(), path / "metadata.csv")

--- a/airbase/parquet_api/__init__.py
+++ b/airbase/parquet_api/__init__.py
@@ -1,11 +1,5 @@
 from .client import Client
-from .dataset import (
-    AggregationType,
-    Dataset,
-    ParquetData,
-    request_info_by_city,
-    request_info_by_country,
-)
+from .dataset import AggregationType, Dataset, ParquetData, request_info
 from .session import Session, download
 
 __all__ = [
@@ -13,8 +7,7 @@ __all__ = [
     "Client",
     "Dataset",
     "ParquetData",
-    "request_info_by_city",
-    "request_info_by_country",
+    "request_info",
     "Session",
     "download",
 ]

--- a/airbase/parquet_api/dataset.py
+++ b/airbase/parquet_api/dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection, Iterator
 from enum import Enum, IntEnum
 from typing import NamedTuple
 from warnings import warn
@@ -81,45 +82,39 @@ class ParquetData(NamedTuple):
 
 def request_info_by_city(
     dataset: Dataset,
-    *cities,
-    pollutants: frozenset[str] | set[str] | None = None,
+    *cities: str,
+    pollutants: Collection[str] | None = None,
     frequency: AggregationType | None = None,
-) -> set[ParquetData]:
+) -> Iterator[ParquetData]:
     """download info one city at the time"""
     if not pollutants:
         pollutants = None
-    if isinstance(pollutants, set):
+    else:
         pollutants = frozenset(pollutants)
 
-    info: set[ParquetData] = set()
     for city in cities:
         if (country := DB.search_city(city)) is None:
             warn(f"Unknown {city=}, skip", UserWarning, stacklevel=-2)
             continue
 
-        info.add(ParquetData(country, dataset, pollutants, city, frequency))
-
-    return info
+        yield ParquetData(country, dataset, pollutants, city, frequency)
 
 
 def request_info_by_country(
     dataset: Dataset,
-    *countries,
-    pollutants: frozenset[str] | set[str] | None = None,
+    *countries: str,
+    pollutants: Collection[str] | None = None,
     frequency: AggregationType | None = None,
-) -> set[ParquetData]:
+) -> Iterator[ParquetData]:
     """download info one country at the time"""
     if not pollutants:
         pollutants = None
-    if isinstance(pollutants, set):
+    else:
         pollutants = frozenset(pollutants)
 
-    info: set[ParquetData] = set()
     for country in countries:
         if country not in DB.COUNTRY_CODES:
             warn(f"Unknown {country=}, skip", UserWarning, stacklevel=-2)
             continue
 
-        info.add(ParquetData(country, dataset, pollutants, frequency=frequency))
-
-    return info
+        yield ParquetData(country, dataset, pollutants, frequency=frequency)

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -27,6 +27,8 @@ _T = TypeVar("_T")
 
 
 class Session(AbstractAsyncContextManager):
+    """Parquet downloads API session"""
+
     client: Client = Client()
 
     def __init__(
@@ -332,19 +334,18 @@ async def download(
     info: Iterable[ParquetData],
     root_path: Path,
     *,
+    session: Session,
     summary_only: bool = False,
     metadata: bool = False,
     country_subdir: bool = True,
     overwrite: bool = False,
-    quiet: bool = True,
-    raise_for_status: bool = False,
-    session: Session = Session(),
 ):
     """
     request file urls and download unique files
 
     :param info: requests by country|city/pollutant.
     :param root_path: The directory to save files in (must exist).
+    :param session: Parquet downloads API session.
     :param summary_only: (optional, default `False`)
         Request total files/size, nothing will be downloaded.
     :param metadata: (optional, default `False`)
@@ -356,14 +357,7 @@ async def download(
         Re-download existing files in `root_path`.
         If False, existing files will be skipped.
         Empty files will be re-downloaded regardless of this option.
-    :param quiet: (optional, default `True`)
-        Disable progress bars.
-    :param raise_for_status: (optional, default `False`)
-        Raise exceptions if any request return "bad" HTTP status codes.
-        If False, a :py:func:`warnings.warn` will be issued instead.
     """
-    session.progress = not quiet
-    session.raise_for_status = raise_for_status
     if summary_only:
         async with session:
             await session.summary(*info)

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -344,12 +344,15 @@ async def download(
     request file urls and download unique files
 
     :param info: requests by country|city/pollutant.
-    :param root_path: The directory to save files in (must exist).
+    :param root_path:
+        The directory to save files in (must exist)
+        or file path to write station metadata into,
+        depending on the value of `metadata_only`.
     :param session: Parquet downloads API session.
     :param metadata_only: (optional, default `False`)
-        Only download station metadata into `root_path/"metadata.csv"`
-        if `root_path/` is an (existing) directory
-        or into `root_path` is a file with ".csv" or ".tsv "suffix.
+        Only download station metadata into `root_path`,
+        it assumes that `root_path` is a file path
+        instad of a directory.
     :param summary_only: (optional, default `False`)
         Request total files/size, nothing will be downloaded.
     :param country_subdir: (optional, default `True`)
@@ -361,12 +364,10 @@ async def download(
         Empty files will be re-downloaded regardless of this option.
     """
     if metadata_only:
-        if root_path.suffix in {".csv", ".tsv"}:
-            path = root_path
-        else:
-            path = root_path / "metadata.csv"
         async with session:
-            await session.download_metadata(path, skip_existing=not overwrite)
+            await session.download_metadata(
+                root_path, skip_existing=not overwrite
+            )
         return
 
     if summary_only:

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -415,12 +415,11 @@ async def download(
 
         await session.url_to_files(*info)
         if session.number_of_urls == 0:
-            warn(
-                "Found no data matching your selection, please try different cites/pollutants"
-                if cities
-                else "Found no data matching your selection, please try different pollutants",
-                UserWarning,
-            )
+            if cities:
+                hint = "please try different cites/pollutants"
+            else:
+                hint = "please try different countries/pollutants"
+            warn(f"Found no data matching your selection, {hint}", UserWarning)
             return
 
         await session.download_to_directory(

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -382,6 +382,9 @@ async def download(
                 f"found {session.expected_files:_} file(s), ~{session.expected_size:_} Mb in total",
                 file=sys.stderr,
             )
+        # https://github.com/pallets/click/issues/2682
+        # click CliRunner does not flush sys.stderr, so we do it here
+        sys.stderr.flush()
         return
 
     async with session:

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from collections import defaultdict
-from collections.abc import (
-    AsyncIterator,
-    Awaitable,
-    Collection,
-    Iterable,
-    Iterator,
-)
+from collections.abc import AsyncIterator, Awaitable, Iterable, Iterator
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from types import TracebackType
@@ -27,7 +21,7 @@ from tqdm import tqdm
 
 from ..summary import DB
 from .client import Client
-from .dataset import AggregationType, Dataset, ParquetData, request_info
+from .dataset import ParquetData
 
 _T = TypeVar("_T")
 
@@ -335,13 +329,9 @@ def pollutant_id_from_url(url: str) -> int:
 
 
 async def download(
-    dataset: Dataset,
+    info: Iterable[ParquetData],
     root_path: Path,
     *,
-    countries: Collection[str] | None = None,
-    pollutants: Collection[str] | None = None,
-    cities: Collection[str] | None = None,
-    frequency: AggregationType | None = None,
     summary_only: bool = False,
     metadata: bool = False,
     country_subdir: bool = True,
@@ -351,17 +341,10 @@ async def download(
     session: Session = Session(),
 ):
     """
-    request file urls by country|city/pollutant and download unique files
+    request file urls and download unique files
 
-    :param dataset: `Dataset.Historical`, `Dataset.Verified` or `Dataset.Unverified`.
+    :param info: requests by country|city/pollutant.
     :param root_path: The directory to save files in (must exist).
-    :param countries: (optional, default `None`)
-        Request observations for these countries.
-        `None` or an empy container means all countries.
-    :param pollutants: (optional, default `None`)
-        Limit requests to these specific pollutants.
-    :param cities: (optional, default `None`)
-        Limit requests to these specific cities.
     :param summary_only: (optional, default `False`)
         Request total files/size, nothing will be downloaded.
     :param metadata: (optional, default `False`)
@@ -379,14 +362,6 @@ async def download(
         Raise exceptions if any request return "bad" HTTP status codes.
         If False, a :py:func:`warnings.warn` will be issued instead.
     """
-    info = request_info(
-        dataset,
-        cities=cities,
-        countries=countries,
-        pollutants=pollutants,
-        frequency=frequency,
-    )
-
     session.progress = not quiet
     session.raise_for_status = raise_for_status
     if summary_only:
@@ -407,10 +382,7 @@ async def download(
 
         await session.url_to_files(*info)
         if session.number_of_urls == 0:
-            if cities:
-                hint = "please try different cites/pollutants"
-            else:
-                hint = "please try different countries/pollutants"
+            hint = "please try different countries|cites/pollutants"
             warn(f"Found no data matching your selection, {hint}", UserWarning)
             return
 

--- a/airbase/parquet_api/session.py
+++ b/airbase/parquet_api/session.py
@@ -388,13 +388,6 @@ async def download(
             dataset, *countries, pollutants=pollutants, frequency=frequency
         )
 
-    if not info:
-        warn(
-            "No data to download, please check the download options",
-            UserWarning,
-        )
-        return
-
     session.progress = not quiet
     session.raise_for_status = raise_for_status
     if summary_only:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,24 +81,24 @@ Historical data delivered between 2002 and 2012
      Historical Airbase data delivered between 2002 and 2012 before Air Quality
      Directive 2008/50/EC entered into force.
 
-     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+     or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
      - download only Norwegian, Danish and Finish sites
        airbase historical -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase historical -p SO2 -p PM10 -p PM2.5
-
-     Use -C/--city to further restrict the download to specific cities, e.g.
      - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase historical -C Valletta -c MT -p PM10 -p PM2.5
+       airbase historical -C Valletta -p PM10 -p PM2.5
 
    Options:
      -c, --country [AD|AL|AT|...]
      -p, --pollutant [k|V|NT|...]
-     -C, --city TEXT                 only from selected <cities>
+     -C, --city TEXT                 Only from selected <cities> (--country
+                                     option will be ignored).
      -F, --aggregation-type, --frequency [hourly|daily|other]
-                                     only hourly data, daily data or other
-                                     aggregation frequency
-     -M, --metadata                  download station metadata
+                                     Only hourly data, daily data or other
+                                     aggregation frequency.
+     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/historical]
      -n, --dry-run, --summary        Total download files/size, nothing will be
                                      downloaded.
@@ -116,24 +116,24 @@ Verified data from 2013 to 2023
      Verified data (E1a) from 2013 to 2023 reported by countries by 30 September
      each year for the previous year.
 
-     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+     or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
      - download only Norwegian, Danish and Finish sites
        airbase verified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase verified -p SO2 -p PM10 -p PM2.5
-
-     Use -C/--city to further restrict the download to specific cities, e.g.
      - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase verified -C Valletta -c MT -p PM10 -p PM2.5
+       airbase verified -C Valletta -p PM10 -p PM2.5
 
    Options:
      -c, --country [AD|AL|AT|...]
      -p, --pollutant [k|V|NT|...]
-     -C, --city TEXT                 only from selected <cities>
+     -C, --city TEXT                 Only from selected <cities> (--country
+                                     option will be ignored).
      -F, --aggregation-type, --frequency [hourly|daily|other]
-                                     only hourly data, daily data or other
-                                     aggregation frequency
-     -M, --metadata                  download station metadata
+                                     Only hourly data, daily data or other
+                                     aggregation frequency.
+     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/verified]
      -n, --dry-run, --summary        Total download files/size, nothing will be
                                      downloaded.
@@ -150,24 +150,24 @@ Unverified data from the beginning of 2024
      Unverified data transmitted continuously (Up-To-Date/UTD/E2a) data from the
      beginning of 2024.
 
-     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants, e.g.
+     Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+     or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
      - download only Norwegian, Danish and Finish sites
        airbase unverified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase unverified -p SO2 -p PM10 -p PM2.5
-
-     Use -C/--city to further restrict the download to specific cities, e.g.
      - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase unverified -C Valletta -c MT -p PM10 -p PM2.5
+       airbase unverified -C Valletta -p PM10 -p PM2.5
 
    Options:
      -c, --country [AD|AL|AT|...]
      -p, --pollutant [k|V|NT|...]
-     -C, --city TEXT                 only from selected <cities>
+     -C, --city TEXT                 Only from selected <cities> (--country
+                                     option will be ignored).
      -F, --aggregation-type, --frequency [hourly|daily|other]
-                                     only hourly data, daily data or other
-                                     aggregation frequency
-     -M, --metadata                  download station metadata
+                                     Only hourly data, daily data or other
+                                     aggregation frequency.
+     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/unverified]
      -n, --dry-run, --summary        Total download files/size, nothing will be
                                      downloaded.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -106,7 +106,7 @@ To install ``airbase``, simply run
    historical  Historical Airbase data delivered between 2002 and 2012...
    verified    Verified data (E1a) from 2013 to 2023 reported by countries...
    unverified  Unverified data transmitted continuously...
-   metadata    Download station metadata into `PATH/metadata.csv`.
+   metadata    Download station metadata.
 
 
 Historical data delivered between 2002 and 2012
@@ -208,7 +208,7 @@ Station metadata
    $ airbase metadata --help
    Usage: airbase metadata [OPTIONS]
 
-     Download station metadata into `PATH/metadata.csv`.
+     Download station metadata.
 
    Use chan notation to download metadata and observations, e.g.
    - download station metadata and hourly PM10 and PM2.5 observations
@@ -221,6 +221,7 @@ Station metadata
 
    Options:
      --path PATH  [default: data]
+     --metadata   Station metadata. [default: PATH/metadata.csv]
      --help       Show this message and exit.
 
 Key Concepts

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,29 @@ To install ``airbase``, simply run
 🚆 Command line interface
 =========================
 
+.. code-block:: console
+
+   $ airbase --help
+   Usage: airbase [OPTIONS] COMMAND [ARGS]...
+
+      Download Air Quality Data from the European Environment Agency (EEA)
+
+   Options:
+      -V, --version
+      -n, --dry-run, --summary  Total download files/size, nothing will be
+                                 downloaded.
+      --subdir / --no-subdir    Download files for different counties to different
+                                 sub directories.  [default: subdir]
+      -O, --overwrite           Re-download existing files.
+      -q, --quiet               No progress-bar.
+      --help                    Show this message and exit.
+
+   Commands:
+      historical  Historical Airbase data delivered between 2002 and 2012...
+      verified    Verified data (E1a) from 2013 to 2023 reported by countries...
+      unverified  Unverified data transmitted continuously...
+
+
 Historical data delivered between 2002 and 2012
 -----------------------------------------------
 
@@ -83,7 +106,7 @@ Historical data delivered between 2002 and 2012
 
      Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
      or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-     - download only Norwegian, Danish and Finish sites
+     - download only from Norwegian, Danish and Finish sites
        airbase historical -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase historical -p SO2 -p PM10 -p PM2.5
@@ -100,16 +123,13 @@ Historical data delivered between 2002 and 2012
                                      aggregation frequency.
      -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/historical]
-     -n, --dry-run, --summary        Total download files/size, nothing will be
-                                     downloaded.
-     -O, --overwrite                 Re-download existing files.
-     -q, --quiet                     No progress-bar.
      --help                          Show this message and exit.
 
 
 Verified data from 2013 to 2023
 -------------------------------
 .. code-block:: console
+
    $ airbase verified --help
    Usage: airbase verified [OPTIONS]
 
@@ -118,7 +138,7 @@ Verified data from 2013 to 2023
 
      Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
      or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-     - download only Norwegian, Danish and Finish sites
+     - download only from Norwegian, Danish and Finish sites
        airbase verified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase verified -p SO2 -p PM10 -p PM2.5
@@ -135,15 +155,12 @@ Verified data from 2013 to 2023
                                      aggregation frequency.
      -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/verified]
-     -n, --dry-run, --summary        Total download files/size, nothing will be
-                                     downloaded.
-     -O, --overwrite                 Re-download existing files.
-     -q, --quiet                     No progress-bar.
      --help                          Show this message and exit.
 
 Unverified data from the beginning of 2024
 ------------------------------------------
 .. code-block:: console
+
    $ airbase unverified --help
    Usage: airbase unverified [OPTIONS]
 
@@ -152,7 +169,7 @@ Unverified data from the beginning of 2024
 
      Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
      or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
-     - download only Norwegian, Danish and Finish sites
+     - download only from Norwegian, Danish and Finish sites
        airbase unverified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase unverified -p SO2 -p PM10 -p PM2.5
@@ -169,10 +186,6 @@ Unverified data from the beginning of 2024
                                      aggregation frequency.
      -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/unverified]
-     -n, --dry-run, --summary        Total download files/size, nothing will be
-                                     downloaded.
-     -O, --overwrite                 Re-download existing files.
-     -q, --quiet                     No progress-bar.
      --help                          Show this message and exit.
 
 Key Concepts

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,17 +80,17 @@ To install ``airbase``, simply run
    Use -n/--dry-run/--summary and -q/--quiet to request the number of files and
    estimated download size without downloading the observations, e.g
    - total download files/size for hourly verified and unverified observations
-      airbase --quiet --summary \
-         verified -F hourly \
-         unverified -F hourly
+     airbase --quiet --summary \
+       verified -F hourly \
+       unverified -F hourly
 
    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
    or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
    - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
-      to different (existing) paths in order to avoid filename collisions
-      airbase --no-subdir \
-         verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
-         verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
+     to different (existing) paths in order to avoid filename collisions
+     airbase --no-subdir \
+       verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
+       verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
 
    Options:
    -V, --version
@@ -136,7 +136,6 @@ Historical data delivered between 2002 and 2012
      -F, --aggregation-type, --frequency [hourly|daily|other]
                                      Only hourly data, daily data or other
                                      aggregation frequency.
-     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/historical]
      --help                          Show this message and exit.
 
@@ -168,7 +167,6 @@ Verified data from 2013 to 2023
      -F, --aggregation-type, --frequency [hourly|daily|other]
                                      Only hourly data, daily data or other
                                      aggregation frequency.
-     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/verified]
      --help                          Show this message and exit.
 
@@ -199,9 +197,23 @@ Unverified data from the beginning of 2024
      -F, --aggregation-type, --frequency [hourly|daily|other]
                                      Only hourly data, daily data or other
                                      aggregation frequency.
-     -M, --metadata                  Download station metadata.
      --path PATH                     [default: data/unverified]
      --help                          Show this message and exit.
+
+Station metadata
+----------------
+.. code-block:: console
+
+   $ airbase metadata --help
+   Usage: airbase metadata [OPTIONS] [PATH]
+
+     Download station metadata.
+
+   Arguments:
+     [PATH]  [default: data/metadata.csv]
+
+   Options:
+     --help  Show this message and exit.
 
 Key Concepts
 ============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ To install ``airbase``, simply run
    Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
    or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
    - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
-     to different (existing) paths in order to avoid filename collisions
+     into different (existing) paths in order to avoid filename collisions
      airbase --no-subdir \
        verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
        verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
@@ -106,6 +106,7 @@ To install ``airbase``, simply run
    historical  Historical Airbase data delivered between 2002 and 2012...
    verified    Verified data (E1a) from 2013 to 2023 reported by countries...
    unverified  Unverified data transmitted continuously...
+   metadata    Download station metadata into `PATH/metadata.csv`.
 
 
 Historical data delivered between 2002 and 2012
@@ -205,15 +206,22 @@ Station metadata
 .. code-block:: console
 
    $ airbase metadata --help
-   Usage: airbase metadata [OPTIONS] [PATH]
+   Usage: airbase metadata [OPTIONS]
 
-     Download station metadata.
+     Download station metadata into `PATH/metadata.csv`.
 
-   Arguments:
-     [PATH]  [default: data/metadata.csv]
+   Use chan notation to donwload metadata and observations, e.g.
+   - donwload station metadata and hourly PM10 and PM2.5 observations
+     from sites in Oslo into into different paths
+       airbase --quiet --no-subdir \
+         historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \
+         verified   --path data/verified   -F hourly -p PM10 -p PM2.5 -C Oslo \
+         unverified --path data/unverified -F hourly -p PM10 -p PM2.5 -C Oslo \
+         metadata   --path data/
 
    Options:
-     --help  Show this message and exit.
+     --path PATH  [default: data]
+     --help       Show this message and exit.
 
 Key Concepts
 ============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,24 +73,39 @@ To install ``airbase``, simply run
 .. code-block:: console
 
    $ airbase --help
-   Usage: airbase [OPTIONS] COMMAND [ARGS]...
+   Usage: airbase [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
-      Download Air Quality Data from the European Environment Agency (EEA)
+   Download Air Quality Data from the European Environment Agency (EEA)
+
+   Use -n/--dry-run/--summary and -q/--quiet to request the number of files and
+   estimated download size without downloading the observations, e.g
+   - total download files/size for hourly verified and unverified observations
+      airbase --quiet --summary \
+         verified -F hourly \
+         unverified -F hourly
+
+   Use -c/--country and -p/--pollutant to restrict the download specific countries and pollutants,
+   or -C/--city and -p/--pollutant to restrict the download specific cities and pollutants, e.g.
+   - download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo
+      to different (existing) paths in order to avoid filename collisions
+      airbase --no-subdir \
+         verified -p PM10 -p PM2.5 -C Oslo -F daily  --path data/daily \
+         verified -p PM10 -p PM2.5 -C Oslo -F hourly --path data/hourly
 
    Options:
-      -V, --version
-      -n, --dry-run, --summary  Total download files/size, nothing will be
-                                 downloaded.
-      --subdir / --no-subdir    Download files for different counties to different
-                                 sub directories.  [default: subdir]
-      -O, --overwrite           Re-download existing files.
-      -q, --quiet               No progress-bar.
-      --help                    Show this message and exit.
+   -V, --version
+   -n, --dry-run, --summary  Total download files/size, nothing will be
+                              downloaded.
+   --subdir / --no-subdir    Download files for different counties to different
+                              sub directories.  [default: subdir]
+   -O, --overwrite           Re-download existing files.
+   -q, --quiet               No progress-bar.
+   --help                    Show this message and exit.
 
    Commands:
-      historical  Historical Airbase data delivered between 2002 and 2012...
-      verified    Verified data (E1a) from 2013 to 2023 reported by countries...
-      unverified  Unverified data transmitted continuously...
+   historical  Historical Airbase data delivered between 2002 and 2012...
+   verified    Verified data (E1a) from 2013 to 2023 reported by countries...
+   unverified  Unverified data transmitted continuously...
 
 
 Historical data delivered between 2002 and 2012
@@ -110,8 +125,8 @@ Historical data delivered between 2002 and 2012
        airbase historical -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase historical -p SO2 -p PM10 -p PM2.5
-     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase historical -C Valletta -p PM10 -p PM2.5
+     - download only PM10 and PM2.5 observations from sites in Oslo
+       airbase historical -p PM10 -p PM2.5 -C Oslo
 
    Options:
      -c, --country [AD|AL|AT|...]
@@ -142,8 +157,8 @@ Verified data from 2013 to 2023
        airbase verified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase verified -p SO2 -p PM10 -p PM2.5
-     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase verified -C Valletta -p PM10 -p PM2.5
+     - download only PM10 and PM2.5 observations from sites in Oslo
+       airbase verified -p PM10 -p PM2.5 -C Oslo
 
    Options:
      -c, --country [AD|AL|AT|...]
@@ -173,8 +188,8 @@ Unverified data from the beginning of 2024
        airbase unverified -c NO -c DK -c FI
      - download only SO2, PM10 and PM2.5 observations
        airbase unverified -p SO2 -p PM10 -p PM2.5
-     - download only PM10 and PM2.5 from Valletta, the Capital of Malta
-       airbase unverified -C Valletta -p PM10 -p PM2.5
+     - download only PM10 and PM2.5 observations from sites in Oslo
+       airbase unverified -p PM10 -p PM2.5 -C Oslo
 
    Options:
      -c, --country [AD|AL|AT|...]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -210,8 +210,8 @@ Station metadata
 
      Download station metadata into `PATH/metadata.csv`.
 
-   Use chan notation to donwload metadata and observations, e.g.
-   - donwload station metadata and hourly PM10 and PM2.5 observations
+   Use chan notation to download metadata and observations, e.g.
+   - download station metadata and hourly PM10 and PM2.5 observations
      from sites in Oslo into into different paths
        airbase --quiet --no-subdir \
          historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,11 +131,11 @@ description = non-interation tests
 package = wheel
 wheel_build_env = {package_env}
 setenv =
-    COVERAGE_FILE = .coverage.{envname}
+    py39,py310,py311,py312,py313,integration: COVERAGE_FILE = .coverage.{envname}
 commands =
     pytest -ra -q --cov --no-cov-on-fail -k "not integration"
 dependency_groups =
-    test
+    py39,py310,py311,py312,py313,integration: test
 
 [testenv:integration]
 description = interation tests
@@ -146,8 +146,6 @@ commands =
 description = combined coverage report
 skip_install = true
 parallel_show_output = True
-setenv =
-    COVERAGE_FILE = .coverage
 commands =
     coverage combine --keep
     coverage report
@@ -168,7 +166,7 @@ deps =
 
 [testenv:docs]
 description = build docs
-skip_install = True
+skip_install = False
 commands =
     sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs/source docs/build
 dependency_groups =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ Documentation = "https://airbase.readthedocs.io"
 [project.scripts]
 airbase = "airbase.cli:main"
 
+[project.optional-dependencies]
+typer = ["typer-slim[standard] >=0.12.0"]
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -11,19 +11,19 @@ runner = CliRunner()
 
 
 @pytest.mark.parametrize(
-    "cmd,country,city,pollutant,expected",
+    "cmd,city,pollutant,expected",
     (
         pytest.param(
-            "historical", "MT", "Valletta", "PM2.5",
+            "historical", "Valletta", "PM2.5",
             {"MT/SPO-MT00005_06001_100.parquet"},
             id="historical",
         ),
         pytest.param(
-            "verified", "MT", "Valletta", "O3",
+            "verified", "Valletta", "O3",
             {"MT/SPO-MT00003_00007_100.parquet", "MT/SPO-MT00005_00007_100.parquet"},
             id="verified"),
         pytest.param(
-            "unverified", "MT", "Valletta", "PM10",
+            "unverified", "Valletta", "PM10",
             {"MT/SPO-MT00005_00005_100.parquet", "MT/SPO-MT00005_00005_101.parquet"},
             id="unverified"
         ),
@@ -31,36 +31,35 @@ runner = CliRunner()
 )  # fmt:skip
 def test_download(
     cmd: str,
-    country: str,
     city: str,
     pollutant: str,
     expected: set[str],
     tmp_path: Path,
 ):
-    options = f"{cmd} --quiet --country {country} --city {city} --pollutant {pollutant} --path {tmp_path}"
+    options = f"{cmd} --quiet --city {city} --pollutant {pollutant}"
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        result = runner.invoke(main, options.split())
-        assert result.exit_code == 0
+        result = runner.invoke(main, f"{options} --path {tmp_path}")
+    assert result.exit_code == 0
 
-    found = set(tmp_path.rglob("*.*"))
+    found = set(tmp_path.glob("MT/*.parquet"))
     paths = set(tmp_path / file for file in expected)
     assert found >= paths > set()
 
 
 @pytest.mark.parametrize(
-    "cmd,country,city,pollutant,expected",
+    "cmd,city,pollutant,expected",
     (
         pytest.param(
-            "historical", "MT", "Valletta", "PM2.5",
+            "historical", "Valletta", "PM2.5",
             "found 1 file(s), ~0 Mb in total",
             id="historical",
         ),
         pytest.param(
-            "verified", "MT", "Valletta", "O3",
+            "verified", "Valletta", "O3",
             "found 2 file(s), ~1 Mb in total",
             id="verified"),
         pytest.param(
-            "unverified", "MT", "Valletta", "PM10",
+            "unverified", "Valletta", "PM10",
             "found 2 file(s), ~0 Mb in total",
             id="unverified"
         ),
@@ -68,17 +67,18 @@ def test_download(
 )  # fmt:skip
 def test_summary(
     cmd: str,
-    country: str,
     city: str,
     pollutant: str,
     expected: str,
     tmp_path: Path,
 ):
-    options = f"{cmd} --quiet --country {country} --city {city} --pollutant {pollutant} --path {tmp_path} --aggregation-type hourly --summary"
+    options = f"{cmd} --quiet --summary --city {city} --pollutant {pollutant}"
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        result = runner.invoke(main, options.split())
-        assert result.exit_code == 0
-        assert expected in result.stdout
+        result = runner.invoke(
+            main, f"{options} --path {tmp_path} --frequency hourly"
+        )
+    assert result.exit_code == 0
+    assert expected in result.stdout
 
-    files = tuple(tmp_path.rglob("*.parquet"))
+    files = tuple(tmp_path.glob("MT/*.parquet"))
     assert not files

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -64,7 +64,7 @@ def test_summary(tmp_path: Path):
         "unverified hourly": "found 2 file(s), ~0 Mb in total",
     }
     for key, val in summary.items():
-        assert f"{key}\n{val}\n" in result.stdout, key
+        assert f"{key}\n{val}\n" in result.output, key
 
     files = tuple(tmp_path.rglob("*.*"))
     assert not files

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -36,9 +36,9 @@ def test_download(
     expected: set[str],
     tmp_path: Path,
 ):
-    options = f"{cmd} --quiet --city {city} --pollutant {pollutant}"
+    options = f"{cmd} --city {city} --pollutant {pollutant}"
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        result = runner.invoke(main, f"{options} --path {tmp_path}")
+        result = runner.invoke(main, f"--quiet {options} --path {tmp_path}")
     assert result.exit_code == 0
 
     found = set(tmp_path.glob("MT/*.parquet"))
@@ -72,10 +72,10 @@ def test_summary(
     expected: str,
     tmp_path: Path,
 ):
-    options = f"{cmd} --quiet --summary --city {city} --pollutant {pollutant}"
+    options = f"--summary {cmd} --city {city} --pollutant {pollutant}"
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
-            main, f"{options} --path {tmp_path} --frequency hourly"
+            main, f"--quiet {options} --path {tmp_path} --frequency hourly"
         )
     assert result.exit_code == 0
     assert expected in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from typer.testing import CliRunner
@@ -29,6 +31,16 @@ def test_version(options: str):
     assert str(__version__) in result.output
 
 
+@pytest.mark.parametrize("dataset", ("historical", "verified", "unverified"))
+@pytest.mark.usefixtures("mock_parquet_api")
+def test_download(
+    tmp_path: Path, dataset: Literal["historical", "verified", "unverified"]
+):
+    result = runner.invoke(main, f"{dataset} --city Valletta --path {tmp_path}")
+    assert result.exit_code == 0
+    assert sum(1 for _ in tmp_path.glob("MT/*.parquet")) == 22
+
+
 @pytest.mark.parametrize(
     "metadata",
     (
@@ -41,3 +53,43 @@ def test_metadata(tmp_path: Path, metadata: str | None):
     result = runner.invoke(main, f"metadata {tmp_path}/{metadata or ''}")
     assert result.exit_code == 0
     assert tmp_path.joinpath(metadata or "metadata.csv").is_file()
+
+
+@pytest.mark.usefixtures("mock_parquet_api")
+def test_download_chain(tmp_path):
+    commands = (
+        "--quiet --no-subdir",
+        f"historical --city Valletta --path {tmp_path}/historical",
+        f"  verified --city Valletta --path {tmp_path}/verified",
+        f"unverified --city Valletta --path {tmp_path}/unverified",
+        f"metadata {tmp_path}",
+    )
+    tmp_path.joinpath("historical").mkdir()
+    tmp_path.joinpath("verified").mkdir()
+    tmp_path.joinpath("unverified").mkdir()
+    result = runner.invoke(main, " ".join(commands))
+    assert result.exit_code == 0
+
+    counter = Counter(path.parts[-2] for path in tmp_path.rglob("*.parquet"))
+    assert counter == {"historical": 22, "verified": 22, "unverified": 22}
+    assert tmp_path.joinpath("metadata.csv").is_file()
+
+
+@pytest.mark.usefixtures("mock_parquet_api")
+def test_summary_chain(tmp_path):
+    commands = (
+        "--quiet --summary",
+        f"historical --city Valletta --path {tmp_path}",
+        f"  verified --city Valletta --path {tmp_path}",
+        f"unverified --city Valletta --path {tmp_path}",
+    )
+    result = runner.invoke(main, " ".join(commands))
+    assert result.exit_code == 0
+
+    summary = "found 22 file(s), ~11 Mb in total"
+    assert f"historical\n{summary}\n" in result.stdout, "historical"
+    assert f"verified\n{summary}\n" in result.stdout, "verified"
+    assert f"unverified\n{summary}\n" in result.stdout, "unverified"
+
+    files = tuple(tmp_path.rglob("*.*"))
+    assert not files

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,18 +57,18 @@ def test_download(
 
 
 @pytest.mark.parametrize(
-    "path",
+    "option,path",
     (
-        pytest.param(None, id="dir"),
-        pytest.param("data", id="csv"),
+        pytest.param(None, "data", id="default"),
+        pytest.param("--path dir", "dir", id="dir"),
     ),
 )
 @pytest.mark.usefixtures("mock_parquet_api")
-def test_metadata(tmp_path: Path, path: str | None):
-    metadata = tmp_path.joinpath(path or "", "metadata.csv")
-    result = runner.invoke(main, f"metadata {metadata.parent}")
+def test_metadata(tmp_path: Path, option: str | None, path: str):
+    with chdir(tmp_path):
+        result = runner.invoke(main, f"metadata {option or ''}")
     assert result.exit_code == 0
-    assert metadata.is_file()
+    assert tmp_path.joinpath(path, "metadata.csv").is_file()
 
 
 @pytest.mark.usefixtures("mock_parquet_api")
@@ -78,7 +78,7 @@ def test_download_chain(tmp_path: Path):
         "historical --city Valletta",
         "  verified --city Valletta",
         "unverified --city Valletta",
-        "metadata data",
+        "metadata",
     )
     with chdir(tmp_path):
         result = runner.invoke(main, " ".join(commands))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
 
@@ -21,7 +23,21 @@ def test_pollutant(pollutant: Pollutant):
 
 @pytest.mark.parametrize("options", ("--version", "-V"))
 def test_version(options: str):
-    result = runner.invoke(main, options.split())
+    result = runner.invoke(main, options)
     assert result.exit_code == 0
     assert "airbase" in result.output
     assert str(__version__) in result.output
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    (
+        pytest.param(None, id="dir"),
+        pytest.param("meta.csv", id="csv"),
+    ),
+)
+@pytest.mark.usefixtures("mock_parquet_api")
+def test_metadata(tmp_path: Path, metadata: str | None):
+    result = runner.invoke(main, f"metadata {tmp_path}/{metadata or ''}")
+    assert result.exit_code == 0
+    assert tmp_path.joinpath(metadata or "metadata.csv").is_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,8 +108,8 @@ def test_summary_chain(tmp_path: Path):
     assert result.exit_code == 0
 
     summary = "found 22 file(s), ~11 Mb in total"
-    assert f"historical\n{summary}\n" in result.stdout, "historical"
-    assert f"verified\n{summary}\n" in result.stdout, "verified"
-    assert f"unverified\n{summary}\n" in result.stdout, "unverified"
+    assert f"historical\n{summary}\n" in result.output, "historical"
+    assert f"verified\n{summary}\n" in result.output, "verified"
+    assert f"unverified\n{summary}\n" in result.output, "unverified"
 
     assert counter == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,16 +59,17 @@ def test_download(
 @pytest.mark.parametrize(
     "option,path",
     (
-        pytest.param(None, "data", id="default"),
-        pytest.param("--path dir", "dir", id="dir"),
+        pytest.param("", "data/metadata.csv", id="default"),
+        pytest.param("--path dir", "dir/metadata.csv", id="path"),
+        pytest.param("--metadata meta.csv", "meta.csv", id="meta"),
     ),
 )
 @pytest.mark.usefixtures("mock_parquet_api")
-def test_metadata(tmp_path: Path, option: str | None, path: str):
+def test_metadata(tmp_path: Path, option: str, path: str):
     with chdir(tmp_path):
-        result = runner.invoke(main, f"metadata {option or ''}")
+        result = runner.invoke(main, f"metadata {option}")
     assert result.exit_code == 0
-    assert tmp_path.joinpath(path, "metadata.csv").is_file()
+    assert tmp_path.joinpath(path).is_file()
 
 
 @pytest.mark.usefixtures("mock_parquet_api")

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -57,18 +57,15 @@ def test_request_info_by_city(
     frequency: AggregationType | None,
     dataset: Dataset = Dataset.Historical,
 ):
+    info = request_info_by_city(
+        dataset, city, pollutants=pollutants, frequency=frequency
+    )
     if not pollutants:
-        assert (
-            request_info_by_city(dataset, city, frequency=frequency)
-            == request_info_by_city(
-                dataset, city, pollutants=set(), frequency=frequency
-            )
-            == {ParquetData(country, dataset, city=city, frequency=frequency)}
-        )
+        assert set(info) == {
+            ParquetData(country, dataset, None, city, frequency)
+        }
     else:
-        assert request_info_by_city(
-            dataset, city, pollutants=pollutants, frequency=frequency
-        ) == {
+        assert set(info) == {
             ParquetData(
                 country, dataset, frozenset(pollutants), city, frequency
             )
@@ -80,7 +77,7 @@ def test_request_info_by_city_warning(
     dataset: Dataset = Dataset.Historical,
 ):
     with pytest.warns(UserWarning, match=rf"Unknown city='{city}'"):
-        assert not request_info_by_city(dataset, city)
+        assert not set(request_info_by_city(dataset, city))
 
 
 @pytest.mark.parametrize(
@@ -97,20 +94,18 @@ def test_request_info_by_country(
     frequency: AggregationType | None,
     dataset: Dataset = Dataset.Historical,
 ):
+    info = request_info_by_country(
+        dataset, country, pollutants=pollutants, frequency=frequency
+    )
     if not pollutants:
-        assert (
-            request_info_by_country(dataset, country, frequency=frequency)
-            == request_info_by_country(
-                dataset, country, pollutants=set(), frequency=frequency
-            )
-            == {ParquetData(country, dataset, frequency=frequency)}
-        )
+        assert set(info) == {
+            ParquetData(country, dataset, None, None, frequency)
+        }
+
     else:
-        assert request_info_by_country(
-            dataset, country, pollutants=pollutants, frequency=frequency
-        ) == {
+        assert set(info) == {
             ParquetData(
-                country, dataset, frozenset(pollutants), frequency=frequency
+                country, dataset, frozenset(pollutants), None, frequency
             )
         }
 
@@ -120,7 +115,7 @@ def test_request_info_by_country_warning(
     dataset: Dataset = Dataset.Historical,
 ):
     with pytest.warns(UserWarning, match=rf"Unknown country='{country}'"):
-        assert not request_info_by_country(dataset, country)
+        assert not set(request_info_by_country(dataset, country))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -366,7 +366,7 @@ async def test_download(tmp_path: Path, session: Session):
     assert not tuple(tmp_path.rglob("*.parquet"))
     assert not tuple(tmp_path.rglob("*.csv"))
     info = request_info(Dataset.Historical, cities={"Valletta"})
-    await download(session, info, tmp_path)
+    await download("PARQUET", session, info, tmp_path)
     assert len(tuple(tmp_path.glob("MT/*.parquet"))) == 22
 
 
@@ -376,6 +376,6 @@ async def test_download_metadata(tmp_path: Path, session: Session):
     assert not tuple(tmp_path.rglob("*.csv"))
     info = request_info(Dataset.Historical, cities={"Valletta"})
     metadata = tmp_path / "meta.csv"
-    await download(session, info, metadata, metadata_only=True)
+    await download("METADATA", session, info, metadata)
     assert not tuple(tmp_path.rglob("*.parquet"))
     assert tuple(tmp_path.rglob("*.csv")) == (metadata,)

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -13,8 +13,7 @@ from airbase.parquet_api import (
     ParquetData,
     Session,
     download,
-    request_info_by_city,
-    request_info_by_country,
+    request_info,
 )
 from airbase.summary import DB
 from tests.resources import CSV_PARQUET_URLS_RESPONSE
@@ -57,8 +56,8 @@ def test_request_info_by_city(
     frequency: AggregationType | None,
     dataset: Dataset = Dataset.Historical,
 ):
-    info = request_info_by_city(
-        dataset, city, pollutants=pollutants, frequency=frequency
+    info = request_info(
+        dataset, cities={city}, pollutants=pollutants, frequency=frequency
     )
     if not pollutants:
         assert set(info) == {
@@ -77,7 +76,7 @@ def test_request_info_by_city_warning(
     dataset: Dataset = Dataset.Historical,
 ):
     with pytest.warns(UserWarning, match=rf"Unknown city='{city}'"):
-        assert not set(request_info_by_city(dataset, city))
+        assert not set(request_info(dataset, cities={city}))
 
 
 @pytest.mark.parametrize(
@@ -94,8 +93,8 @@ def test_request_info_by_country(
     frequency: AggregationType | None,
     dataset: Dataset = Dataset.Historical,
 ):
-    info = request_info_by_country(
-        dataset, country, pollutants=pollutants, frequency=frequency
+    info = request_info(
+        dataset, countries={country}, pollutants=pollutants, frequency=frequency
     )
     if not pollutants:
         assert set(info) == {
@@ -115,7 +114,7 @@ def test_request_info_by_country_warning(
     dataset: Dataset = Dataset.Historical,
 ):
     with pytest.warns(UserWarning, match=rf"Unknown country='{country}'"):
-        assert not set(request_info_by_country(dataset, country))
+        assert not set(request_info(dataset, countries={country}))
 
 
 @pytest.mark.parametrize(
@@ -369,7 +368,6 @@ async def test_download(tmp_path: Path, session: Session):
     await download(
         Dataset.Historical,
         tmp_path,
-        countries={"MT"},
         cities={"Valletta"},
         metadata=True,
         session=session,

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -366,6 +366,15 @@ async def test_download(tmp_path: Path, session: Session):
     assert not tuple(tmp_path.rglob("*.parquet"))
     assert not tuple(tmp_path.rglob("*.csv"))
     info = request_info(Dataset.Historical, cities={"Valletta"})
-    await download(info, tmp_path, metadata=True, session=session)
+    await download(session, info, tmp_path)
     assert len(tuple(tmp_path.glob("MT/*.parquet"))) == 22
+
+
+@pytest.mark.asyncio
+async def test_download_metadata(tmp_path: Path, session: Session):
+    assert not tuple(tmp_path.rglob("*.parquet"))
+    assert not tuple(tmp_path.rglob("*.csv"))
+    info = request_info(Dataset.Historical, cities={"Valletta"})
+    await download(session, info, tmp_path, metadata_only=True)
+    assert not tuple(tmp_path.rglob("*.parquet"))
     assert tmp_path.joinpath("metadata.csv").is_file()

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -365,12 +365,7 @@ async def test_Session_download_metadata(tmp_path: Path, session: Session):
 async def test_download(tmp_path: Path, session: Session):
     assert not tuple(tmp_path.rglob("*.parquet"))
     assert not tuple(tmp_path.rglob("*.csv"))
-    await download(
-        Dataset.Historical,
-        tmp_path,
-        cities={"Valletta"},
-        metadata=True,
-        session=session,
-    )
+    info = request_info(Dataset.Historical, cities={"Valletta"})
+    await download(info, tmp_path, metadata=True, session=session)
     assert len(tuple(tmp_path.glob("MT/*.parquet"))) == 22
     assert tmp_path.joinpath("metadata.csv").is_file()

--- a/tests/test_parquet_api.py
+++ b/tests/test_parquet_api.py
@@ -375,6 +375,7 @@ async def test_download_metadata(tmp_path: Path, session: Session):
     assert not tuple(tmp_path.rglob("*.parquet"))
     assert not tuple(tmp_path.rglob("*.csv"))
     info = request_info(Dataset.Historical, cities={"Valletta"})
-    await download(session, info, tmp_path, metadata_only=True)
+    metadata = tmp_path / "meta.csv"
+    await download(session, info, metadata, metadata_only=True)
     assert not tuple(tmp_path.rglob("*.parquet"))
-    assert tmp_path.joinpath("metadata.csv").is_file()
+    assert tuple(tmp_path.rglob("*.csv")) == (metadata,)

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,11 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
+[package.optional-dependencies]
+typer = [
+    { name = "typer-slim", extra = ["standard"] },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "aioresponses" },
@@ -196,8 +201,10 @@ requires-dist = [
     { name = "importlib-resources", marker = "python_full_version < '3.11'" },
     { name = "tqdm" },
     { name = "typer-slim", specifier = ">=0.12.0" },
+    { name = "typer-slim", extras = ["standard"], marker = "extra == 'typer'", specifier = ">=0.12.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.12.2" },
 ]
+provides-extras = ["typer"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -617,6 +624,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -682,6 +701,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946 },
     { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063 },
     { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -1042,6 +1070,20 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1064,6 +1106,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/52/047f35d3b20fd1ae9ccfe28791ef0f3ca0ef0b3e6c1a58badd97d450131b/ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe", size = 10320697 },
     { url = "https://files.pythonhosted.org/packages/b9/fe/00c78010e3332a6e92762424cf4c1919065707e962232797d0b57fd8267e/ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800", size = 11378665 },
     { url = "https://files.pythonhosted.org/packages/43/7c/c83fe5cbb70ff017612ff36654edfebec4b1ef79b558b8e5fd933bab836b/ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e", size = 10460287 },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
 ]
 
 [[package]]
@@ -1246,6 +1297,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/67/88189eb827c491646511dc6c806e2e6e543241cae5438383aa042b1dfa40/typer_slim-0.15.2.tar.gz", hash = "sha256:4a666bb7839a88f51dd25d078d36dbc1d0f37c8c2696e184fbc1f3eaa314a91b", size = 100755 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/84/9b68e98bf7417d25e38b27a0296bfcbc6719b15d7000f4c09d9716fa9d11/typer_slim-0.15.2-py3-none-any.whl", hash = "sha256:4273014a3378b24367bffed45c2ce8dd3d85bd201a6f02e51ba6b19f336009be", size = 45117 },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 
 [[package]]


### PR DESCRIPTION
Move options around in order to construct chained one-liners, e.g.

- download verified hourly and daily PM10 and PM2.5 observations from sites in Oslo into different paths in order to avoid filename collisions
``` console
# summary
$ airbase --quiet --summary \
    verified -p PM10 -p PM2.5 -C Oslo -F daily  \
    verified -p PM10 -p PM2.5 -C Oslo -F hourly
airbase verified daily
found 30 file(s), ~30 Mb in total
airbase verified hourly
found 30 file(s), ~30 Mb in total

# download
$ airbase --no-subdir \
    verified --path data/daily  -F daily  -p PM10 -p PM2.5 -C Oslo \
    verified --path data/hourly -F hourly -p PM10 -p PM2.5 -C Oslo
[...]
```

- download station metadata and hourly PM10 and PM2.5 observations from sites in Oslo into into different paths
``` console
# summary
$ airbase --quiet --summary \
    historical -p PM10 -p PM2.5 -C Oslo -F hourly \
    verified   -p PM10 -p PM2.5 -C Oslo -F hourly \
    unverified -p PM10 -p PM2.5 -C Oslo -F hourly
airbase verified hourly
found 30 file(s), ~30 Mb in total
airbase unverified hourly
found 28 file(s), ~5 Mb in total
airbase historical hourly
found 22 file(s), ~10 Mb in total

# donwload
$ airbase --no-subdir \
    historical --path data/historical -F hourly -p PM10 -p PM2.5 -C Oslo \
    verified   --path data/verified   -F hourly -p PM10 -p PM2.5 -C Oslo \
    unverified --path data/unverified -F hourly -p PM10 -p PM2.5 -C Oslo \
    metadata   --path data/
[...]
```