### PR TITLE
patch country code for Lichtenstein

### DIFF
--- a/airbase/plugins/catalog.py
+++ b/airbase/plugins/catalog.py
@@ -43,6 +43,7 @@ def station_metadata(path: Path) -> pl.DataFrame:
         "Kosovo under UNSCR 1244/99": DB.COUNTRY_CODE["Kosovo"],
         "Ukraine": DB.COUNTRY_CODE.get("Ukraine", "UA"),
         "Georgia": DB.COUNTRY_CODE.get("Georgia", "GE"),
+        "Lichtenstein": DB.COUNTRY_CODE.get("Lichtenstein", "LI"),
     }
     time_zone = {
         "UTC-04": "Etc/GMT-4",


### PR DESCRIPTION
fixes the `.replace_strict(country_code)` failure due to the fact that the metadata csv has now also entries for Lichtenstein